### PR TITLE
refactor: redesign layout for mobile-first experience

### DIFF
--- a/src/components/CategoryList.tsx
+++ b/src/components/CategoryList.tsx
@@ -1,8 +1,6 @@
-
-import React from 'react';
-import { Badge } from '@/components/ui/badge';
-import { useNavigate } from 'react-router-dom';
-import { formatCurrency } from '@/lib/formatters';
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { formatCurrency } from "@/lib/formatters";
 
 interface Category {
   id: string;
@@ -14,7 +12,6 @@ interface Category {
 
 interface CategoryListProps {
   categories: Category[];
-  selectedMonth: Date;
 }
 
 export const CategoryList: React.FC<CategoryListProps> = ({ categories }) => {
@@ -22,8 +19,8 @@ export const CategoryList: React.FC<CategoryListProps> = ({ categories }) => {
 
   if (categories.length === 0) {
     return (
-      <div className="text-center py-8 text-gray-500">
-        <div className="text-4xl mb-2">🏷️</div>
+      <div className="py-8 text-center text-sm text-slate-500">
+        <div className="mb-2 text-3xl">🏷️</div>
         <p>No hay categorías con gastos</p>
       </div>
     );
@@ -34,31 +31,28 @@ export const CategoryList: React.FC<CategoryListProps> = ({ categories }) => {
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       {categories.map((category) => (
-        <div 
+        <button
           key={category.id}
-          className="flex items-center justify-between p-3 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+          type="button"
           onClick={() => handleCategoryClick(category.name)}
+          className="flex w-full items-center justify-between rounded-xl border border-blue-100 bg-blue-50/40 p-3 text-left transition-colors hover:bg-blue-50"
         >
           <div className="flex items-center gap-3">
-            <div 
-              className="w-4 h-4 rounded-full flex-shrink-0"
+            <span
+              className="h-4 w-4 rounded-full"
               style={{ backgroundColor: category.color }}
             />
-            <div>
-              <div className="font-medium flex items-center gap-2">
-                <span>{category.icon}</span>
-                <span>{category.name}</span>
-              </div>
-            </div>
+            <span className="flex items-center gap-2 text-sm font-medium text-slate-900">
+              <span>{category.icon}</span>
+              {category.name}
+            </span>
           </div>
-          <div className="text-right">
-            <div className="font-semibold text-gray-900">
-              {formatCurrency(category.total)}
-            </div>
-          </div>
-        </div>
+          <span className="text-sm font-semibold text-slate-900">
+            {formatCurrency(category.total)}
+          </span>
+        </button>
       ))}
     </div>
   );

--- a/src/components/ExpenseChart.tsx
+++ b/src/components/ExpenseChart.tsx
@@ -1,54 +1,70 @@
-
-import React from 'react';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
-import { Expense } from '@/hooks/useExpenseStore';
-import { formatCurrency } from '@/lib/formatters';
+import type { TooltipProps } from "recharts";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { Expense } from "@/hooks/useExpenseStore";
+import { formatCurrency } from "@/lib/formatters";
 
 interface ExpenseChartProps {
   expenses: Expense[];
 }
 
+interface ChartDatum {
+  name: string;
+  value: number;
+  percentage: string;
+}
+
 const COLORS = [
-  '#10B981', '#3B82F6', '#EF4444', '#8B5CF6', '#F59E0B', 
-  '#EC4899', '#6366F1', '#64748B', '#059669', '#2563EB'
+  "#10B981",
+  "#3B82F6",
+  "#EF4444",
+  "#8B5CF6",
+  "#F59E0B",
+  "#EC4899",
+  "#6366F1",
+  "#64748B",
+  "#059669",
+  "#2563EB",
 ];
 
-export const ExpenseChart: React.FC<ExpenseChartProps> = ({ expenses }) => {
-  const categoryTotals = expenses.reduce((acc, expense) => {
+export const ExpenseChart = ({ expenses }: ExpenseChartProps) => {
+  const categoryTotals = expenses.reduce<Record<string, number>>((acc, expense) => {
     acc[expense.category] = (acc[expense.category] || 0) + expense.amount;
     return acc;
-  }, {} as Record<string, number>);
+  }, {});
 
-  const chartData = Object.entries(categoryTotals)
+  const totalAmount = expenses.reduce((sum, expense) => sum + expense.amount, 0);
+
+  const chartData: ChartDatum[] = Object.entries(categoryTotals)
     .map(([category, total]) => ({
       name: category,
       value: total,
-      percentage: ((total / expenses.reduce((sum, exp) => sum + exp.amount, 0)) * 100).toFixed(1),
+      percentage: ((total / totalAmount) * 100).toFixed(1),
     }))
     .sort((a, b) => b.value - a.value);
 
   if (chartData.length === 0) {
     return (
-      <div className="h-64 flex items-center justify-center text-gray-500">
+      <div className="flex h-64 items-center justify-center text-slate-500">
         <div className="text-center">
-          <div className="text-4xl mb-2">📊</div>
+          <div className="mb-2 text-4xl">📊</div>
           <p>No hay datos para mostrar</p>
         </div>
       </div>
     );
   }
 
-  const CustomTooltip = ({ active, payload }: any) => {
+  const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
     if (active && payload && payload.length) {
-      const data = payload[0].payload;
+      const data = payload[0].payload as ChartDatum;
       return (
-        <div className="bg-white p-3 border border-gray-200 rounded-lg shadow-lg">
-          <p className="font-medium">{data.name}</p>
-          <p className="text-blue-600">{formatCurrency(data.value)}</p>
-          <p className="text-gray-500 text-sm">{data.percentage}%</p>
+        <div className="rounded-lg border border-blue-100 bg-white p-3 shadow-md">
+          <p className="font-medium text-slate-900">{data.name}</p>
+          <p className="text-sm text-blue-600">{formatCurrency(data.value)}</p>
+          <p className="text-xs text-slate-500">{data.percentage}%</p>
         </div>
       );
     }
+
     return null;
   };
 

--- a/src/components/FloatingExpenseButton.tsx
+++ b/src/components/FloatingExpenseButton.tsx
@@ -9,9 +9,9 @@ export const FloatingExpenseButton = () => {
 
   return (
     <>
-      <Button 
+      <Button
         onClick={() => setShowExpenseForm(true)}
-        className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 z-50"
+        className="fixed bottom-24 right-5 z-50 h-14 w-14 rounded-full bg-gradient-to-r from-blue-500 to-blue-600 shadow-lg hover:from-blue-600 hover:to-blue-700 sm:bottom-8 sm:right-8"
         size="icon"
       >
         <Plus size={24} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,11 +1,33 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, Link } from "react-router-dom";
+import { PiggyBank } from "lucide-react";
 import SideMenu from "@/components/SideMenu";
 
 export function Layout() {
   return (
-    <div>
-      <SideMenu />
-      <Outlet />
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-100">
+      <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col">
+        <header className="sticky top-0 z-40 border-b border-white/60 bg-white/80 backdrop-blur">
+          <div className="flex h-16 items-center justify-between px-4 sm:px-6">
+            <Link to="/" className="flex items-center gap-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white shadow-sm">
+                <PiggyBank className="h-5 w-5" />
+              </span>
+              <div className="flex flex-col leading-tight">
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+                  Mis gastos
+                </span>
+                <span className="text-sm font-semibold text-slate-900">
+                  Panel financiero
+                </span>
+              </div>
+            </Link>
+            <SideMenu />
+          </div>
+        </header>
+        <main className="flex-1 px-4 pb-28 pt-6 sm:px-6">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/components/MonthNavigator.tsx
+++ b/src/components/MonthNavigator.tsx
@@ -1,16 +1,15 @@
-
-import React from 'react';
-import { Button } from '@/components/ui/button';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface MonthNavigatorProps {
   selectedMonth: Date;
   onMonthChange: (date: Date) => void;
 }
 
-export const MonthNavigator: React.FC<MonthNavigatorProps> = ({ 
-  selectedMonth, 
-  onMonthChange 
+export const MonthNavigator: React.FC<MonthNavigatorProps> = ({
+  selectedMonth,
+  onMonthChange,
 }) => {
   const goToPreviousMonth = () => {
     const newDate = new Date(selectedMonth);
@@ -28,50 +27,54 @@ export const MonthNavigator: React.FC<MonthNavigatorProps> = ({
     onMonthChange(new Date());
   };
 
-  const isCurrentMonth = 
+  const isCurrentMonth =
     selectedMonth.getMonth() === new Date().getMonth() &&
     selectedMonth.getFullYear() === new Date().getFullYear();
 
-  const monthText = selectedMonth.toLocaleDateString('es', { 
-    month: 'long', 
-    year: 'numeric' 
+  const monthText = selectedMonth.toLocaleDateString("es", {
+    month: "long",
+    year: "numeric",
   });
 
   return (
-    <div className="flex items-center justify-between bg-white rounded-lg p-4 shadow-sm">
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={goToPreviousMonth}
-        className="h-10 w-10"
-      >
-        <ChevronLeft size={16} />
-      </Button>
-
-      <div className="flex items-center gap-4">
-        <h2 className="text-xl font-semibold capitalize text-gray-900">
-          {monthText}
-        </h2>
-        {!isCurrentMonth && (
+    <div className="rounded-2xl border border-blue-100 bg-white/90 p-4 shadow-sm backdrop-blur">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex w-full items-center justify-between gap-3">
           <Button
             variant="outline"
-            size="sm"
-            onClick={goToCurrentMonth}
-            className="text-blue-600 border-blue-200 hover:bg-blue-50"
+            size="icon"
+            onClick={goToPreviousMonth}
+            className="h-10 w-10 rounded-full"
           >
-            Mes actual
+            <ChevronLeft size={16} />
           </Button>
-        )}
-      </div>
 
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={goToNextMonth}
-        className="h-10 w-10"
-      >
-        <ChevronRight size={16} />
-      </Button>
+          <div className="flex flex-1 flex-col items-center gap-2 text-center sm:flex-row sm:justify-center sm:text-left">
+            <h2 className="text-xl font-semibold capitalize text-slate-900">
+              {monthText}
+            </h2>
+            {!isCurrentMonth && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={goToCurrentMonth}
+                className="border-blue-200 text-blue-600 hover:bg-blue-50"
+              >
+                Mes actual
+              </Button>
+            )}
+          </div>
+
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={goToNextMonth}
+            className="h-10 w-10 rounded-full"
+          >
+            <ChevronRight size={16} />
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,46 +1,71 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
-import { Menu, X } from "lucide-react";
+import { Menu } from "lucide-react";
+import { NavLink } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+const navigationItems = [
+  { to: "/", label: "Inicio" },
+  { to: "/projected", label: "Gastos proyectados" },
+];
+
+const getLinkClasses = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    "rounded-full px-4 py-2 text-sm font-medium transition-colors",
+    isActive
+      ? "bg-blue-600 text-white shadow-sm"
+      : "text-slate-600 hover:bg-blue-50 hover:text-blue-600"
+  );
 
 export function SideMenu() {
-  const [open, setOpen] = useState(false);
-
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <Button
-        variant="outline"
-        size="icon"
-        className="fixed top-4 right-4 z-50"
-        onClick={() => setOpen((prev) => !prev)}
-      >
-        {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
-        <span className="sr-only">{open ? "Cerrar" : "Abrir"} menú</span>
-      </Button>
-      <SheetContent side="left" className="w-64">
-        <VisuallyHidden>
-          <SheetTitle>Menú de navegación</SheetTitle>
-        </VisuallyHidden>
-        <nav className="mt-8 flex flex-col gap-4">
-          <Link
-            to="/"
-            className="text-lg font-medium"
-            onClick={() => setOpen(false)}
+    <>
+      <nav className="hidden items-center gap-2 md:flex">
+        {navigationItems.map((item) => (
+          <NavLink key={item.to} to={item.to} className={getLinkClasses}>
+            {item.label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon"
+            className="md:hidden h-10 w-10 rounded-full border-blue-200 bg-white/90 shadow-sm"
           >
-            Inicio
-          </Link>
-          <Link
-            to="/projected"
-            className="text-lg font-medium"
-            onClick={() => setOpen(false)}
-          >
-            Gastos proyectados
-          </Link>
-        </nav>
-      </SheetContent>
-    </Sheet>
+            <Menu className="h-5 w-5 text-slate-700" />
+            <span className="sr-only">Abrir menú</span>
+          </Button>
+        </SheetTrigger>
+        <SheetContent
+          side="left"
+          className="w-full max-w-xs border-r border-blue-100 bg-gradient-to-b from-white to-blue-50 p-0"
+        >
+          <div className="px-6 pb-2 pt-8">
+            <SheetTitle className="text-left text-lg font-semibold text-slate-900">
+              Navegación
+            </SheetTitle>
+          </div>
+          <nav className="flex flex-col gap-2 px-6 pb-6">
+            {navigationItems.map((item) => (
+              <SheetClose asChild key={item.to}>
+                <NavLink to={item.to} className={getLinkClasses}>
+                  {item.label}
+                </NavLink>
+              </SheetClose>
+            ))}
+          </nav>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -1,167 +1,156 @@
-import React, { useState } from 'react';
-import { ArrowLeft, Calendar, DollarSign } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import { Expense, useExpenseStore } from '@/hooks/useExpenseStore';
-import { formatCurrency } from '@/lib/formatters';
-import { FloatingExpenseButton } from '@/components/FloatingExpenseButton';
-import { EditExpenseModal } from '@/components/EditExpenseModal';
+import { useState } from "react";
+import { ArrowLeft, Calendar, DollarSign } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { Expense, useExpenseStore } from "@/hooks/useExpenseStore";
+import { formatCurrency } from "@/lib/formatters";
+import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
+import { EditExpenseModal } from "@/components/EditExpenseModal";
 
 const CategoryDetail = () => {
   const { category } = useParams<{ category: string }>();
   const navigate = useNavigate();
-  const { expenses, categories, getExpensesForMonth } = useExpenseStore();
-  
-  const selectedMonth = new Date(); // Por ahora usamos el mes actual, se puede expandir
-  
-  const categoryInfo = categories.find(cat => cat.name === category);
-  const categoryExpenses = expenses.filter(expense => 
-    expense.category === category &&
-    new Date(expense.date).getMonth() === selectedMonth.getMonth() &&
-    new Date(expense.date).getFullYear() === selectedMonth.getFullYear()
+  const { expenses, categories, updateExpense } = useExpenseStore();
+
+  const selectedMonth = new Date();
+
+  const categoryInfo = categories.find((cat) => cat.name === category);
+  const categoryExpenses = expenses.filter(
+    (expense) =>
+      expense.category === category &&
+      new Date(expense.date).getMonth() === selectedMonth.getMonth() &&
+      new Date(expense.date).getFullYear() === selectedMonth.getFullYear(),
   );
 
   const totalAmount = categoryExpenses.reduce((sum, expense) => sum + expense.amount, 0);
 
-  const { updateExpense } = useExpenseStore();
-const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
   if (!categoryInfo) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
-        <div className="max-w-4xl mx-auto">
-          <Card className="text-center py-12">
-            <CardContent>
-              <h2 className="text-xl font-semibold mb-4">Categoría no encontrada</h2>
-              <Button onClick={() => navigate('/')}>Volver al inicio</Button>
-            </CardContent>
-          </Card>
-        </div>
+      <div className="space-y-6 pb-14">
+        <Card className="border border-blue-100 bg-white/90 py-12 text-center shadow-sm backdrop-blur">
+          <CardContent className="space-y-3">
+            <h2 className="text-xl font-semibold text-slate-900">Categoría no encontrada</h2>
+            <Button onClick={() => navigate("/")}>Volver al inicio</Button>
+          </CardContent>
+        </Card>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
-      <div className="max-w-4xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex items-center gap-4">
-          <Link to="/">
-            <Button variant="outline" size="icon">
-              <ArrowLeft size={20} />
-            </Button>
-          </Link>
-          <div className="flex items-center gap-3">
-            <div 
-              className="w-6 h-6 rounded-full"
-              style={{ backgroundColor: categoryInfo.color }}
-            />
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-                <span>{categoryInfo.icon}</span>
-                {categoryInfo.name}
-              </h1>
-              <p className="text-gray-600">
-                Gastos de {selectedMonth.toLocaleDateString('es', { month: 'long', year: 'numeric' })}
-              </p>
-            </div>
+    <div className="space-y-6 pb-14">
+      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <Link to="/" className="inline-flex">
+          <Button variant="outline" size="icon" className="h-10 w-10 rounded-full">
+            <ArrowLeft size={20} />
+          </Button>
+        </Link>
+        <div className="flex items-center gap-3">
+          <span
+            className="flex h-10 w-10 items-center justify-center rounded-full text-lg"
+            style={{ backgroundColor: categoryInfo.color }}
+          >
+            {categoryInfo.icon}
+          </span>
+          <div className="flex flex-col gap-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+              Gastos por categoría
+            </p>
+            <h1 className="text-2xl font-bold text-slate-900 sm:text-3xl">{categoryInfo.name}</h1>
+            <p className="text-sm text-slate-600">
+              Gastos de {selectedMonth.toLocaleDateString("es", { month: "long", year: "numeric" })}
+            </p>
           </div>
         </div>
+      </section>
 
-        {/* Summary Card */}
-        <Card className="bg-gradient-to-r from-blue-500 to-blue-600 text-white">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <DollarSign size={16} />
-              Total en {categoryInfo.name}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold">{formatCurrency(totalAmount)}</div>
-            <p className="text-blue-100 text-sm">
-              {categoryExpenses.length} {categoryExpenses.length === 1 ? 'gasto' : 'gastos'} registrados
-            </p>
-          </CardContent>
-        </Card>
+      <Card className="border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <DollarSign size={16} />
+            Total en {categoryInfo.name}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <p className="text-3xl font-semibold leading-tight">{formatCurrency(totalAmount)}</p>
+          <p className="text-xs uppercase tracking-wide text-blue-100">
+            {categoryExpenses.length} {categoryExpenses.length === 1 ? "gasto" : "gastos"} registrados
+          </p>
+        </CardContent>
+      </Card>
 
-        {/* Expenses List */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Calendar className="text-blue-600" size={20} />
-              Detalle de Gastos
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {categoryExpenses.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
-                <div className="text-4xl mb-2">{categoryInfo.icon}</div>
-                <h3 className="text-lg font-medium">No hay gastos registrados</h3>
-                <p>No tienes gastos en esta categoría para este mes</p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {categoryExpenses
-                  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-                  .map((expense) => (
-                    <div 
-  key={expense.id} 
-  className="flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors"
->
-  <div className="flex-1">
-    <div className="font-medium text-gray-900 mb-1">
-      {expense.description}
-    </div>
-    <div className="flex items-center gap-3 text-sm text-gray-500">
-      <span className="flex items-center gap-1">
-        <Calendar size={14} />
-        {new Date(expense.date).toLocaleDateString('es')}
-      </span>
-      {expense.installments && (
-        <Badge variant="outline" className="text-xs">
-          Cuota {expense.installments.current}/{expense.installments.total}
-        </Badge>
+      <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Calendar className="text-blue-600" size={20} />
+            Detalle de gastos
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {categoryExpenses.length === 0 ? (
+            <div className="py-8 text-center text-sm text-slate-500">
+              <div className="mb-2 text-3xl">{categoryInfo.icon}</div>
+              <p>No hay gastos registrados en esta categoría para este mes.</p>
+            </div>
+          ) : (
+            categoryExpenses
+              .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+              .map((expense) => (
+                <div
+                  key={expense.id}
+                  className="flex items-start justify-between gap-3 rounded-xl border border-blue-100 bg-blue-50/40 p-4"
+                >
+                  <div className="flex-1 space-y-1">
+                    <p className="font-medium text-slate-900">{expense.description}</p>
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                      <span className="flex items-center gap-1">
+                        <Calendar size={14} />
+                        {new Date(expense.date).toLocaleDateString("es")}
+                      </span>
+                      {expense.installments && (
+                        <Badge variant="outline" className="text-xs">
+                          Cuota {expense.installments.current}/{expense.installments.total}
+                        </Badge>
+                      )}
+                    </div>
+                    {expense.installments && (
+                      <p className="text-xs text-slate-400">
+                        Total original: {formatCurrency(expense.installments.originalAmount)}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    <button
+                      onClick={() => setEditingExpense(expense)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                    >
+                      Editar
+                    </button>
+                    <p className="text-lg font-semibold text-slate-900">
+                      {formatCurrency(expense.amount)}
+                    </p>
+                  </div>
+                </div>
+              ))
+          )}
+        </CardContent>
+      </Card>
+
+      {editingExpense && (
+        <EditExpenseModal
+          expense={editingExpense}
+          onSave={(updatedData) => {
+            updateExpense(editingExpense.id, updatedData);
+            setEditingExpense(null);
+          }}
+          onClose={() => setEditingExpense(null)}
+        />
       )}
-    </div>
-    {expense.installments && (
-      <div className="text-xs text-gray-400 mt-1">
-        Total original: {formatCurrency(expense.installments.originalAmount)}
-      </div>
-    )}
-  </div>
-  <div className="flex items-center gap-2">
-    <button
-      onClick={() => setEditingExpense(expense)}
-      className="text-blue-600 hover:text-blue-800 text-sm"
-    >
-      Editar
-    </button>
-    <div className="text-lg font-semibold text-gray-900">
-      {formatCurrency(expense.amount)}
-    </div>
-  </div>
-</div>
-                  ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
 
-      {/* Modal de edición */}
-{editingExpense && (
-  <EditExpenseModal
-    expense={editingExpense}
-    onSave={(updatedData) => {
-      updateExpense(editingExpense.id, updatedData);
-      setEditingExpense(null);
-    }}
-    onClose={() => setEditingExpense(null)}
-  />
-)}
-      
       <FloatingExpenseButton />
     </div>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,132 +1,134 @@
-import { useState } from 'react';
-import { TrendingUp, Calendar, PieChart, DollarSign } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Link } from 'react-router-dom';
-import { ExpenseChart } from '@/components/ExpenseChart';
-import { CategoryList } from '@/components/CategoryList';
-import { MonthNavigator } from '@/components/MonthNavigator';
-import { Expense, useExpenseStore } from '@/hooks/useExpenseStore';
-import { formatCurrency } from '@/lib/formatters';
-import { FloatingExpenseButton } from '@/components/FloatingExpenseButton';
-import { EditExpenseModal } from '@/components/EditExpenseModal'; // Asegúrate de tener este componente
+import { useState } from "react";
+import { TrendingUp, Calendar, PieChart, DollarSign } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Link } from "react-router-dom";
+import { ExpenseChart } from "@/components/ExpenseChart";
+import { CategoryList } from "@/components/CategoryList";
+import { MonthNavigator } from "@/components/MonthNavigator";
+import { Expense, useExpenseStore } from "@/hooks/useExpenseStore";
+import { formatCurrency } from "@/lib/formatters";
+import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
+import { EditExpenseModal } from "@/components/EditExpenseModal";
 
 const Index = () => {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
-  const { getExpensesForMonth, getTotalForMonth, getCategoriesWithTotals } = useExpenseStore();
+  const { getExpensesForMonth, getTotalForMonth, getCategoriesWithTotals, updateExpense } = useExpenseStore();
 
   const monthlyExpenses = getExpensesForMonth(selectedMonth);
   const monthlyTotal = getTotalForMonth(selectedMonth);
   const categoriesWithTotals = getCategoriesWithTotals(selectedMonth);
 
-  const currentMonth = new Date().getMonth() === selectedMonth.getMonth() &&
+  const currentMonth =
+    new Date().getMonth() === selectedMonth.getMonth() &&
     new Date().getFullYear() === selectedMonth.getFullYear();
 
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
-  const { updateExpense } = useExpenseStore(); // Asegúrate de haber agregado `updateExpense` al store
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
-      <div className="max-w-6xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="text-center space-y-2">
-          <h1 className="text-3xl font-bold text-gray-900 flex items-center justify-center gap-2">
-            <DollarSign className="text-green-600" />
-            Mis Gastos
-          </h1>
-          <p className="text-gray-600">Controla tus finanzas de manera simple y efectiva</p>
-        </div>
+    <div className="space-y-6 pb-14">
+      <section className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+          Resumen mensual
+        </p>
+        <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">Mis gastos</h1>
+        <p className="text-sm text-slate-600">
+          Controla tus finanzas de manera simple y efectiva.
+        </p>
+      </section>
 
-        {/* Month Navigator */}
-        <MonthNavigator
-          selectedMonth={selectedMonth}
-          onMonthChange={setSelectedMonth}
-        />
+      <MonthNavigator selectedMonth={selectedMonth} onMonthChange={setSelectedMonth} />
 
-        {/* Summary Cards & Categories */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <Link to="/projected">
-            <Card className="bg-gradient-to-r from-blue-500 to-blue-600 text-white">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium flex items-center gap-2">
-                  <TrendingUp size={16} />
-                  Total del Mes
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">{formatCurrency(monthlyTotal)}</div>
-                <p className="text-blue-100 text-sm">
-                  {currentMonth ? 'Mes actual' : selectedMonth.toLocaleDateString('es', { month: 'long', year: 'numeric' })}
-                </p>
-              </CardContent>
-            </Card>
-          </Link>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Categorías</CardTitle>
+      <section className="grid gap-4 sm:grid-cols-2 sm:gap-6">
+        <Link to="/projected" className="group">
+          <Card className="overflow-hidden border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md transition-transform group-hover:-translate-y-1 group-focus-visible:-translate-y-1">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                <TrendingUp size={16} />
+                Total del mes
+              </CardTitle>
             </CardHeader>
-            <CardContent>
-              <CategoryList
-                categories={categoriesWithTotals}
-                selectedMonth={selectedMonth}
-              />
+            <CardContent className="space-y-1">
+              <p className="text-3xl font-semibold leading-tight">{formatCurrency(monthlyTotal)}</p>
+              <p className="text-xs uppercase tracking-wide text-blue-100">
+                {currentMonth
+                  ? "Mes actual"
+                  : selectedMonth.toLocaleDateString("es", { month: "long", year: "numeric" })}
+              </p>
             </CardContent>
           </Card>
-        </div>
+        </Link>
 
-        {/* Recent Expenses */}
+        <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <PieChart size={18} className="text-blue-600" />
+              Categorías
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <CategoryList categories={categoriesWithTotals} />
+          </CardContent>
+        </Card>
+
         {monthlyExpenses.length > 0 && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Gastos Recientes ({monthlyExpenses.length})</CardTitle>
+          <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur sm:col-span-2">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <PieChart size={18} className="text-blue-600" />
+                Distribución por categoría
+              </CardTitle>
             </CardHeader>
-            <CardContent>
-              <div className="space-y-3">
-                {monthlyExpenses.slice(0, 5).map((expense) => (
-                  <div key={expense.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                    <div className="flex-1">
-                      <div className="font-medium">{expense.description}</div>
-                      <div className="text-sm text-gray-500 flex items-center gap-2">
-                        <Badge variant="secondary">{expense.category}</Badge>
-                        <span>{new Date(expense.date).toLocaleDateString('es')}</span>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() => setEditingExpense(expense)}
-                        className="text-blue-600 hover:text-blue-800 text-sm"
-                      >
-                        Editar
-                      </button>
-                      <div className="text-lg font-semibold text-gray-900">
-                        {formatCurrency(expense.amount)}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
+            <CardContent className="pt-0">
+              <ExpenseChart expenses={monthlyExpenses} />
             </CardContent>
           </Card>
         )}
+      </section>
 
-        {/* Empty State */}
-        {monthlyExpenses.length === 0 && (
-          <Card className="text-center py-12">
-            <CardContent>
-              <div className="text-gray-500 space-y-2">
-                <DollarSign size={48} className="mx-auto text-gray-300" />
-                <h3 className="text-lg font-medium">No hay gastos registrados</h3>
-                <p>Comienza agregando tu primer gasto del mes</p>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-      </div>
+      {monthlyExpenses.length > 0 && (
+        <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Calendar size={18} className="text-blue-600" />
+              Gastos recientes ({monthlyExpenses.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {monthlyExpenses.slice(0, 5).map((expense) => (
+              <button
+                key={expense.id}
+                onClick={() => setEditingExpense(expense)}
+                className="flex w-full items-center justify-between rounded-xl border border-blue-100 bg-blue-50/50 p-3 text-left transition-colors hover:bg-blue-50"
+              >
+                <div className="flex-1 pr-4">
+                  <p className="font-medium text-slate-900">{expense.description}</p>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                    <Badge variant="secondary">{expense.category}</Badge>
+                    <span>{new Date(expense.date).toLocaleDateString("es")}</span>
+                  </div>
+                </div>
+                <div className="text-right text-lg font-semibold text-slate-900">
+                  {formatCurrency(expense.amount)}
+                </div>
+              </button>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {monthlyExpenses.length === 0 && (
+        <Card className="border border-blue-100 bg-white/90 py-12 text-center shadow-sm backdrop-blur">
+          <CardContent className="space-y-3">
+            <DollarSign size={48} className="mx-auto text-blue-200" />
+            <h3 className="text-lg font-medium text-slate-900">No hay gastos registrados</h3>
+            <p className="text-sm text-slate-500">Comienza agregando tu primer gasto del mes.</p>
+          </CardContent>
+        </Card>
+      )}
 
       <FloatingExpenseButton />
 
-      {/* Modal de edición */}
       {editingExpense && (
         <EditExpenseModal
           expense={editingExpense}

--- a/src/pages/MonthDetail.tsx
+++ b/src/pages/MonthDetail.tsx
@@ -1,29 +1,28 @@
-import React from 'react';
-import { ArrowLeft, Calendar, DollarSign, TrendingUp } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import { useExpenseStore } from '@/hooks/useExpenseStore';
-import { formatCurrency, formatMonth } from '@/lib/formatters';
-import { CategoryList } from '@/components/CategoryList';
-import { FloatingExpenseButton } from '@/components/FloatingExpenseButton';
+import { ArrowLeft, Calendar, DollarSign, TrendingUp } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { useExpenseStore } from "@/hooks/useExpenseStore";
+import { formatCurrency, formatMonth } from "@/lib/formatters";
+import { CategoryList } from "@/components/CategoryList";
+import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 
 const MonthDetail = () => {
   const { year, month } = useParams<{ year: string; month: string }>();
   const navigate = useNavigate();
   const { getTotalForMonth, getCategoriesWithTotals } = useExpenseStore();
-  
+
   if (!year || !month) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
-        <div className="max-w-4xl mx-auto">
-          <Card className="text-center py-12">
-            <CardContent>
-              <h2 className="text-xl font-semibold mb-4">Mes no válido</h2>
-              <Button onClick={() => navigate('/projected')}>Volver a gastos proyectados</Button>
-            </CardContent>
-          </Card>
-        </div>
+      <div className="space-y-6 pb-14">
+        <Card className="border border-blue-100 bg-white/90 py-12 text-center shadow-sm backdrop-blur">
+          <CardContent className="space-y-3">
+            <h2 className="text-xl font-semibold text-slate-900">Mes no válido</h2>
+            <Button onClick={() => navigate("/projected")} className="mt-2">
+              Volver a gastos proyectados
+            </Button>
+          </CardContent>
+        </Card>
       </div>
     );
   }
@@ -33,62 +32,59 @@ const MonthDetail = () => {
   const categoriesWithTotals = getCategoriesWithTotals(selectedDate);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
-      <div className="max-w-4xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex items-center gap-4">
-          <Link to="/projected">
-            <Button variant="outline" size="icon">
-              <ArrowLeft size={20} />
-            </Button>
-          </Link>
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-              <Calendar className="text-blue-600" />
-              {formatMonth(selectedDate)}
-            </h1>
-            <p className="text-gray-600">Desglose detallado de gastos</p>
-          </div>
+    <div className="space-y-6 pb-14">
+      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <Link to="/projected" className="inline-flex">
+          <Button variant="outline" size="icon" className="h-10 w-10 rounded-full">
+            <ArrowLeft size={20} />
+          </Button>
+        </Link>
+        <div className="flex flex-col gap-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+            Resumen mensual
+          </p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-900 sm:text-3xl">
+            <Calendar className="text-blue-600" />
+            {formatMonth(selectedDate)}
+          </h1>
+          <p className="text-sm text-slate-600">Desglose detallado de gastos.</p>
         </div>
+      </section>
 
-        {/* Summary Card */}
-        <Card className="bg-gradient-to-r from-blue-500 to-blue-600 text-white">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <DollarSign size={16} />
-              Total del mes
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold">{formatCurrency(totalAmount)}</div>
-            <p className="text-blue-100 text-sm">
-              {categoriesWithTotals.length} {categoriesWithTotals.length === 1 ? 'categoría' : 'categorías'} con gastos
-            </p>
-          </CardContent>
-        </Card>
+      <Card className="border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+            <DollarSign size={16} />
+            Total del mes
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <p className="text-3xl font-semibold leading-tight">{formatCurrency(totalAmount)}</p>
+          <p className="text-xs uppercase tracking-wide text-blue-100">
+            {categoriesWithTotals.length} {categoriesWithTotals.length === 1 ? "categoría" : "categorías"} con gastos
+          </p>
+        </CardContent>
+      </Card>
 
-        {/* Categories Breakdown */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <TrendingUp className="text-blue-600" size={20} />
-              Gastos por Categoría
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {categoriesWithTotals.length === 0 ? (
-              <div className="text-center py-8 text-gray-500">
-                <div className="text-4xl mb-2">📊</div>
-                <h3 className="text-lg font-medium">No hay gastos registrados</h3>
-                <p>No tienes gastos para este mes</p>
-              </div>
-            ) : (
-              <CategoryList categories={categoriesWithTotals} selectedMonth={selectedDate} />
-            )}
-          </CardContent>
-        </Card>
-      </div>
-      
+      <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <TrendingUp className="text-blue-600" size={20} />
+            Gastos por categoría
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {categoriesWithTotals.length === 0 ? (
+            <div className="py-8 text-center text-sm text-slate-500">
+              <div className="mb-2 text-3xl">📊</div>
+              <p>No hay gastos registrados en este mes.</p>
+            </div>
+          ) : (
+            <CategoryList categories={categoriesWithTotals} />
+          )}
+        </CardContent>
+      </Card>
+
       <FloatingExpenseButton />
     </div>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,25 +1,22 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
-      location.pathname
-    );
+    console.error("404 Error: User attempted to access non-existent route:", location.pathname);
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <div className="flex flex-col items-center justify-center gap-4 pb-14 text-center">
+      <div>
+        <h1 className="text-5xl font-bold text-blue-600">404</h1>
+        <p className="text-sm text-slate-500">La página solicitada no existe.</p>
       </div>
+      <Link to="/" className="rounded-full bg-blue-600 px-6 py-2 text-sm font-medium text-white shadow-md transition-colors hover:bg-blue-700">
+        Volver al inicio
+      </Link>
     </div>
   );
 };

--- a/src/pages/ProjectedExpenses.tsx
+++ b/src/pages/ProjectedExpenses.tsx
@@ -1,19 +1,15 @@
-
-import React from 'react';
-import { ArrowLeft, Calendar, TrendingUp, TrendingDown } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { useExpenseStore } from '@/hooks/useExpenseStore';
-import { formatCurrency, formatMonth } from '@/lib/formatters';
-import { Link } from 'react-router-dom';
-import { FloatingExpenseButton } from '@/components/FloatingExpenseButton';
+import { ArrowLeft, Calendar, TrendingUp, TrendingDown } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useExpenseStore } from "@/hooks/useExpenseStore";
+import { formatCurrency, formatMonth } from "@/lib/formatters";
+import { Link } from "react-router-dom";
+import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 
 const ProjectedExpenses = () => {
-  const { getProjectedExpenses, getTotalForMonth } = useExpenseStore();
-  const projectedData = getProjectedExpenses();
+  const { getTotalForMonth } = useExpenseStore();
 
-  // Generate 12 months starting from current month - 6 to current month + 5
   const currentDate = new Date();
   const months = Array.from({ length: 12 }, (_, i) => {
     const date = new Date(currentDate);
@@ -26,7 +22,6 @@ const ProjectedExpenses = () => {
 
   const getMonthData = (date: Date) => {
     const total = getTotalForMonth(date);
-    const monthKey = date.toISOString().substring(0, 7);
     const isPast = date < new Date(currentYear, currentMonth, 1);
     const isCurrent = date.getMonth() === currentMonth && date.getFullYear() === currentYear;
     const isFuture = date > new Date(currentYear, currentMonth + 1, 0);
@@ -34,132 +29,131 @@ const ProjectedExpenses = () => {
     return {
       date,
       total,
-      monthKey,
       isPast,
       isCurrent,
       isFuture,
-      hasExpenses: total > 0
+      hasExpenses: total > 0,
     };
   };
 
   const monthsData = months.map(getMonthData);
-  const totalPast = monthsData.filter(m => m.isPast).reduce((sum, m) => sum + m.total, 0);
-  const totalFuture = monthsData.filter(m => m.isFuture).reduce((sum, m) => sum + m.total, 0);
-  const currentTotal = monthsData.find(m => m.isCurrent)?.total || 0;
+  const totalPast = monthsData.filter((m) => m.isPast).reduce((sum, m) => sum + m.total, 0);
+  const totalFuture = monthsData.filter((m) => m.isFuture).reduce((sum, m) => sum + m.total, 0);
+  const currentTotal = monthsData.find((m) => m.isCurrent)?.total || 0;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
-      <div className="max-w-4xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex items-center gap-4">
-          <Link to="/">
-            <Button variant="outline" size="icon">
-              <ArrowLeft size={20} />
-            </Button>
-          </Link>
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-              <Calendar className="text-blue-600" />
-              Gastos Proyectados
-            </h1>
-            <p className="text-gray-600">Vista global de todos tus gastos por mes</p>
-          </div>
+    <div className="space-y-6 pb-14">
+      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <Link to="/" className="inline-flex">
+          <Button variant="outline" size="icon" className="h-10 w-10 rounded-full">
+            <ArrowLeft size={20} />
+          </Button>
+        </Link>
+        <div className="flex flex-col gap-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+            Proyección
+          </p>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-900 sm:text-3xl">
+            <Calendar className="text-blue-600" />
+            Gastos proyectados
+          </h1>
+          <p className="text-sm text-slate-600">
+            Vista global de todos tus gastos por mes.
+          </p>
         </div>
+      </section>
 
-        {/* Summary Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Card className="bg-gradient-to-r from-red-500 to-red-600 text-white">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium flex items-center gap-2">
-                <TrendingDown size={16} />
-                Gastos Pasados
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-bold">{formatCurrency(totalPast)}</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gradient-to-r from-blue-500 to-blue-600 text-white">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium">Mes Actual</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-bold">{formatCurrency(currentTotal)}</div>
-            </CardContent>
-          </Card>
-
-          <Card className="bg-gradient-to-r from-green-500 to-green-600 text-white">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium flex items-center gap-2">
-                <TrendingUp size={16} />
-                Gastos Futuros
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-xl font-bold">{formatCurrency(totalFuture)}</div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Monthly Breakdown */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Desglose Mensual</CardTitle>
+      <section className="grid gap-4 sm:grid-cols-3 sm:gap-6">
+        <Card className="border-none bg-gradient-to-r from-red-500 to-red-600 text-white shadow-md">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              <TrendingDown size={16} />
+              Gastos pasados
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {monthsData.map((monthData) => {
-                const { date, total, isPast, isCurrent, isFuture, hasExpenses } = monthData;
-                
-                let cardClass = "bg-gray-50 border-gray-200";
-                let badgeVariant: "default" | "secondary" | "destructive" = "secondary";
-                let statusText = "";
-
-                if (isCurrent) {
-                  cardClass = "bg-blue-50 border-blue-200";
-                  badgeVariant = "default";
-                  statusText = "Actual";
-                } else if (isPast) {
-                  cardClass = hasExpenses ? "bg-red-50 border-red-200" : "bg-gray-50 border-gray-200";
-                  statusText = "Pasado";
-                } else if (isFuture) {
-                  cardClass = hasExpenses ? "bg-green-50 border-green-200" : "bg-gray-50 border-gray-200";
-                  statusText = "Futuro";
-                }
-
-                return (
-                  <Link
-                    key={date.toISOString()}
-                    to={`/month/${date.getFullYear()}/${date.getMonth() + 1}`}
-                    className="block"
-                  >
-                    <div
-                      className={`p-4 rounded-lg border transition-colors hover:shadow-md cursor-pointer ${cardClass}`}
-                    >
-                      <div className="flex items-center justify-between mb-2">
-                        <h3 className="font-medium text-gray-900 capitalize">
-                          {formatMonth(date)}
-                        </h3>
-                        <Badge variant={badgeVariant} className="text-xs">
-                          {statusText}
-                        </Badge>
-                      </div>
-                      <div className="text-lg font-semibold text-gray-900">
-                        {formatCurrency(total)}
-                      </div>
-                      {!hasExpenses && (
-                        <p className="text-sm text-gray-500 mt-1">Sin gastos</p>
-                      )}
-                    </div>
-                  </Link>
-                );
-              })}
-            </div>
+            <p className="text-2xl font-semibold">{formatCurrency(totalPast)}</p>
           </CardContent>
         </Card>
-      </div>
-      
+
+        <Card className="border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Mes actual</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">{formatCurrency(currentTotal)}</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-none bg-gradient-to-r from-green-500 to-green-600 text-white shadow-md">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              <TrendingUp size={16} />
+              Gastos futuros
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">{formatCurrency(totalFuture)}</p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
+        <CardHeader>
+          <CardTitle className="text-base font-semibold">Desglose mensual</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {monthsData.map((monthData) => {
+              const { date, total, isPast, isCurrent, isFuture, hasExpenses } = monthData;
+
+              let cardClass = "bg-blue-50/40 border-blue-100";
+              let badgeVariant: "default" | "secondary" | "destructive" = "secondary";
+              let statusText = "";
+
+              if (isCurrent) {
+                cardClass = "bg-blue-100/60 border-blue-300";
+                badgeVariant = "default";
+                statusText = "Actual";
+              } else if (isPast) {
+                cardClass = hasExpenses ? "bg-red-50/60 border-red-200" : "bg-blue-50/40 border-blue-100";
+                statusText = "Pasado";
+              } else if (isFuture) {
+                cardClass = hasExpenses ? "bg-green-50/60 border-green-200" : "bg-blue-50/40 border-blue-100";
+                statusText = "Futuro";
+              }
+
+              return (
+                <Link
+                  key={date.toISOString()}
+                  to={`/month/${date.getFullYear()}/${date.getMonth() + 1}`}
+                  className="block"
+                >
+                  <div
+                    className={`rounded-xl border p-4 transition-transform hover:-translate-y-1 hover:shadow-md ${cardClass}`}
+                  >
+                    <div className="mb-2 flex items-center justify-between">
+                      <h3 className="text-base font-medium capitalize text-slate-900">
+                        {formatMonth(date)}
+                      </h3>
+                      <Badge variant={badgeVariant} className="text-xs">
+                        {statusText}
+                      </Badge>
+                    </div>
+                    <p className="text-lg font-semibold text-slate-900">
+                      {formatCurrency(total)}
+                    </p>
+                    {!hasExpenses && (
+                      <p className="mt-1 text-xs text-slate-500">Sin gastos</p>
+                    )}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
       <FloatingExpenseButton />
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,96 +1,88 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
-	darkMode: ["class"],
-	content: [
-		"./pages/**/*.{ts,tsx}",
-		"./components/**/*.{ts,tsx}",
-		"./app/**/*.{ts,tsx}",
-		"./src/**/*.{ts,tsx}",
-	],
-	prefix: "",
-	theme: {
-		container: {
-			center: true,
-			padding: '2rem',
-			screens: {
-				'2xl': '1400px'
-			}
-		},
-		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))'
-				},
-				secondary: {
-					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))'
-				},
-				destructive: {
-					DEFAULT: 'hsl(var(--destructive))',
-					foreground: 'hsl(var(--destructive-foreground))'
-				},
-				muted: {
-					DEFAULT: 'hsl(var(--muted))',
-					foreground: 'hsl(var(--muted-foreground))'
-				},
-				accent: {
-					DEFAULT: 'hsl(var(--accent))',
-					foreground: 'hsl(var(--accent-foreground))'
-				},
-				popover: {
-					DEFAULT: 'hsl(var(--popover))',
-					foreground: 'hsl(var(--popover-foreground))'
-				},
-				card: {
-					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))'
-				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-					accent: 'hsl(var(--sidebar-accent))',
-					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-					border: 'hsl(var(--sidebar-border))',
-					ring: 'hsl(var(--sidebar-ring))'
-				}
-			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+  darkMode: ["class"],
+  content: [
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Reorganize the application layout with a sticky mobile header and adaptive navigation
- Refresh the dashboard, monthly, category, and projected expense screens with mobile-first cards and interactions
- Update supporting components for better touch targets, responsive spacing, and stricter typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d53341ddac83308f1edcfe1e4f0b2a