### PR TITLE
feat: redesign home for mobile and enhance navigation

### DIFF
--- a/src/components/CategoryList.tsx
+++ b/src/components/CategoryList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { formatCurrency } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
 
 interface Category {
   id: string;
@@ -30,28 +31,62 @@ export const CategoryList: React.FC<CategoryListProps> = ({ categories }) => {
     navigate(`/category/${encodeURIComponent(categoryName)}`);
   };
 
+  const totalAmount = categories.reduce((sum, category) => sum + category.total, 0);
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {categories.map((category) => (
         <button
           key={category.id}
           type="button"
           onClick={() => handleCategoryClick(category.name)}
-          className="flex w-full items-center justify-between rounded-xl border border-blue-100 bg-blue-50/40 p-3 text-left transition-colors hover:bg-blue-50"
+          className="group w-full rounded-2xl border border-blue-100/60 bg-white/80 p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:bg-white"
         >
-          <div className="flex items-center gap-3">
-            <span
-              className="h-4 w-4 rounded-full"
-              style={{ backgroundColor: category.color }}
-            />
-            <span className="flex items-center gap-2 text-sm font-medium text-slate-900">
-              <span>{category.icon}</span>
-              {category.name}
-            </span>
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <span className="relative flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-50 text-xl shadow-sm">
+                <span
+                  className="absolute inset-0 rounded-2xl opacity-30"
+                  style={{ backgroundColor: category.color }}
+                />
+                <span className="relative drop-shadow-sm">{category.icon}</span>
+              </span>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-slate-900">
+                  {category.name}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  {formatCurrency(category.total)} registrados este mes
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col items-end justify-center gap-1 text-right">
+              <span className="text-sm font-semibold text-slate-900">
+                {formatCurrency(category.total)}
+              </span>
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  totalAmount > 0 ? "text-blue-600" : "text-slate-400"
+                )}
+              >
+                {totalAmount > 0
+                  ? `${Math.round((category.total / totalAmount) * 100)}%`
+                  : "0%"}
+              </span>
+            </div>
           </div>
-          <span className="text-sm font-semibold text-slate-900">
-            {formatCurrency(category.total)}
-          </span>
+          <div className="mt-4">
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-blue-100/60">
+              <div
+                className="h-full rounded-full transition-all"
+                style={{
+                  width: totalAmount > 0 ? `${Math.min(100, Math.round((category.total / totalAmount) * 100))}%` : "0%",
+                  backgroundColor: category.color,
+                }}
+              />
+            </div>
+          </div>
         </button>
       ))}
     </div>

--- a/src/components/ExpenseChart.tsx
+++ b/src/components/ExpenseChart.tsx
@@ -1,10 +1,16 @@
+import type { ReactNode } from "react";
 import type { TooltipProps } from "recharts";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
 import { Expense } from "@/hooks/useExpenseStore";
 import { formatCurrency } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
 
 interface ExpenseChartProps {
   expenses: Expense[];
+  className?: string;
+  innerRadius?: number;
+  outerRadius?: number;
+  centerLabel?: ReactNode;
 }
 
 interface ChartDatum {
@@ -26,7 +32,13 @@ const COLORS = [
   "#2563EB",
 ];
 
-export const ExpenseChart = ({ expenses }: ExpenseChartProps) => {
+export const ExpenseChart = ({
+  expenses,
+  className,
+  innerRadius = 40,
+  outerRadius = 80,
+  centerLabel,
+}: ExpenseChartProps) => {
   const categoryTotals = expenses.reduce<Record<string, number>>((acc, expense) => {
     acc[expense.category] = (acc[expense.category] || 0) + expense.amount;
     return acc;
@@ -69,15 +81,15 @@ export const ExpenseChart = ({ expenses }: ExpenseChartProps) => {
   };
 
   return (
-    <div className="h-64">
+    <div className={cn("relative h-64", className)}>
       <ResponsiveContainer width="100%" height="100%">
         <PieChart>
           <Pie
             data={chartData}
             cx="50%"
             cy="50%"
-            innerRadius={40}
-            outerRadius={80}
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
             paddingAngle={2}
             dataKey="value"
           >
@@ -88,6 +100,11 @@ export const ExpenseChart = ({ expenses }: ExpenseChartProps) => {
           <Tooltip content={<CustomTooltip />} />
         </PieChart>
       </ResponsiveContainer>
+      {centerLabel && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-center">
+          {centerLabel}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/MonthNavigator.tsx
+++ b/src/components/MonthNavigator.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface MonthNavigatorProps {
   selectedMonth: Date;
   onMonthChange: (date: Date) => void;
+  variant?: "default" | "translucent";
+  className?: string;
 }
 
 export const MonthNavigator: React.FC<MonthNavigatorProps> = ({
   selectedMonth,
   onMonthChange,
+  variant = "default",
+  className,
 }) => {
   const goToPreviousMonth = () => {
     const newDate = new Date(selectedMonth);
@@ -36,21 +41,41 @@ export const MonthNavigator: React.FC<MonthNavigatorProps> = ({
     year: "numeric",
   });
 
+  const isTranslucent = variant === "translucent";
+
   return (
-    <div className="rounded-2xl border border-blue-100 bg-white/90 p-4 shadow-sm backdrop-blur">
+    <div
+      className={cn(
+        "rounded-2xl border p-4 shadow-sm backdrop-blur",
+        isTranslucent
+          ? "border-white/40 bg-white/10 text-white"
+          : "border-blue-100 bg-white/90 text-slate-900",
+        className
+      )}
+    >
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex w-full items-center justify-between gap-3">
           <Button
             variant="outline"
             size="icon"
             onClick={goToPreviousMonth}
-            className="h-10 w-10 rounded-full"
+            className={cn(
+              "h-10 w-10 rounded-full",
+              isTranslucent
+                ? "border-white/40 text-white hover:bg-white/20"
+                : "border-blue-200 text-slate-700 hover:bg-blue-50"
+            )}
           >
             <ChevronLeft size={16} />
           </Button>
 
           <div className="flex flex-1 flex-col items-center gap-2 text-center sm:flex-row sm:justify-center sm:text-left">
-            <h2 className="text-xl font-semibold capitalize text-slate-900">
+            <h2
+              className={cn(
+                "text-xl font-semibold capitalize",
+                isTranslucent ? "text-white" : "text-slate-900"
+              )}
+            >
               {monthText}
             </h2>
             {!isCurrentMonth && (
@@ -58,7 +83,12 @@ export const MonthNavigator: React.FC<MonthNavigatorProps> = ({
                 variant="outline"
                 size="sm"
                 onClick={goToCurrentMonth}
-                className="border-blue-200 text-blue-600 hover:bg-blue-50"
+                className={cn(
+                  "rounded-full border",
+                  isTranslucent
+                    ? "border-white/40 bg-white/10 text-white hover:bg-white/20"
+                    : "border-blue-200 text-blue-600 hover:bg-blue-50"
+                )}
               >
                 Mes actual
               </Button>
@@ -69,7 +99,12 @@ export const MonthNavigator: React.FC<MonthNavigatorProps> = ({
             variant="outline"
             size="icon"
             onClick={goToNextMonth}
-            className="h-10 w-10 rounded-full"
+            className={cn(
+              "h-10 w-10 rounded-full",
+              isTranslucent
+                ? "border-white/40 text-white hover:bg-white/20"
+                : "border-blue-200 text-slate-700 hover:bg-blue-50"
+            )}
           >
             <ChevronRight size={16} />
           </Button>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,5 +1,5 @@
-import { Menu } from "lucide-react";
-import { NavLink } from "react-router-dom";
+import { Menu, LogOut } from "lucide-react";
+import { NavLink, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -9,11 +9,18 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
 
-const navigationItems = [
-  { to: "/", label: "Inicio" },
-  { to: "/projected", label: "Gastos proyectados" },
-];
+const getNavigationItems = () => {
+  const today = new Date();
+  const currentMonthPath = `/month/${today.getFullYear()}/${String(today.getMonth() + 1).padStart(2, "0")}`;
+
+  return [
+    { to: "/", label: "Inicio" },
+    { to: currentMonthPath, label: "Detalle del mes" },
+    { to: "/projected", label: "Gastos proyectados" },
+  ];
+};
 
 const getLinkClasses = ({ isActive }: { isActive: boolean }) =>
   cn(
@@ -24,6 +31,19 @@ const getLinkClasses = ({ isActive }: { isActive: boolean }) =>
   );
 
 export function SideMenu() {
+  const navigate = useNavigate();
+  const { signOutUser } = useAuth();
+  const navigationItems = getNavigationItems();
+
+  const handleSignOut = async () => {
+    try {
+      await signOutUser();
+      navigate("/login");
+    } catch (error) {
+      console.error("Error signing out", error);
+    }
+  };
+
   return (
     <>
       <nav className="hidden items-center gap-2 md:flex">
@@ -32,6 +52,14 @@ export function SideMenu() {
             {item.label}
           </NavLink>
         ))}
+        <Button
+          variant="ghost"
+          onClick={handleSignOut}
+          className="ml-2 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 hover:text-blue-600"
+        >
+          <LogOut className="h-4 w-4" />
+          Cerrar sesión
+        </Button>
       </nav>
 
       <Sheet>
@@ -63,6 +91,18 @@ export function SideMenu() {
               </SheetClose>
             ))}
           </nav>
+          <div className="border-t border-blue-100/60 px-6 py-4">
+            <SheetClose asChild>
+              <Button
+                onClick={handleSignOut}
+                variant="outline"
+                className="flex w-full items-center justify-center gap-2 rounded-full border-blue-200 text-slate-700 hover:bg-blue-50"
+              >
+                <LogOut className="h-4 w-4" />
+                Cerrar sesión
+              </Button>
+            </SheetClose>
+          </div>
         </SheetContent>
       </Sheet>
     </>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import { TrendingUp, Calendar, PieChart, DollarSign } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMemo, useState } from "react";
+import { Calendar, Clock, Plus, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Link } from "react-router-dom";
 import { ExpenseChart } from "@/components/ExpenseChart";
@@ -8,126 +7,221 @@ import { CategoryList } from "@/components/CategoryList";
 import { MonthNavigator } from "@/components/MonthNavigator";
 import { Expense, useExpenseStore } from "@/hooks/useExpenseStore";
 import { formatCurrency } from "@/lib/formatters";
-import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 import { EditExpenseModal } from "@/components/EditExpenseModal";
+import { ExpenseForm } from "@/components/ExpenseForm";
 
 const Index = () => {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
+  const [selectedRange, setSelectedRange] = useState("Mes");
+  const [showExpenseForm, setShowExpenseForm] = useState(false);
   const { getExpensesForMonth, getTotalForMonth, getCategoriesWithTotals, updateExpense } = useExpenseStore();
 
   const monthlyExpenses = getExpensesForMonth(selectedMonth);
   const monthlyTotal = getTotalForMonth(selectedMonth);
   const categoriesWithTotals = getCategoriesWithTotals(selectedMonth);
 
-  const currentMonth =
-    new Date().getMonth() === selectedMonth.getMonth() &&
-    new Date().getFullYear() === selectedMonth.getFullYear();
+  const totalCategoriesAmount = useMemo(
+    () => categoriesWithTotals.reduce((sum, category) => sum + category.total, 0),
+    [categoriesWithTotals]
+  );
 
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
+  const monthText = selectedMonth.toLocaleDateString("es", {
+    month: "long",
+    year: "numeric",
+  });
+
+  const timeframeOptions = ["Día", "Semana", "Mes", "Año", "Período"];
+
   return (
-    <div className="space-y-6 pb-14">
-      <section className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
-          Resumen mensual
-        </p>
-        <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">Mis gastos</h1>
-        <p className="text-sm text-slate-600">
-          Controla tus finanzas de manera simple y efectiva.
-        </p>
+    <div className="space-y-6 pb-32 sm:pb-20">
+      <section className="space-y-4">
+        <div className="rounded-3xl bg-gradient-to-br from-emerald-400 via-sky-500 to-indigo-500 p-5 text-white shadow-xl">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] font-semibold uppercase tracking-[0.35em] text-white/70">
+            <span>Gastos</span>
+            <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] tracking-[0.3em] text-white">Total</span>
+          </div>
+
+          <div className="mt-4 space-y-1">
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+              {formatCurrency(monthlyTotal)}
+            </h1>
+            <p className="text-sm capitalize text-white/80">{monthText}</p>
+            <p className="text-xs text-white/70">Controla tus finanzas día a día.</p>
+          </div>
+
+          <div className="mt-5 flex items-center gap-2 overflow-x-auto pb-1">
+            {timeframeOptions.map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setSelectedRange(option)}
+                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition ${
+                  selectedRange === option
+                    ? "bg-white text-sky-600 shadow-sm"
+                    : "bg-white/10 text-white/80 hover:bg-white/20"
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-6 flex flex-col items-center gap-6">
+            <div className="relative flex w-full justify-center">
+              {monthlyExpenses.length > 0 ? (
+                <ExpenseChart
+                  expenses={monthlyExpenses}
+                  className="h-[220px] w-[220px] sm:h-[260px] sm:w-[260px]"
+                  innerRadius={80}
+                  outerRadius={110}
+                  centerLabel={
+                    <div className="flex flex-col items-center text-white">
+                      <span className="text-xs uppercase tracking-[0.25em] text-white/70">
+                        {selectedRange}
+                      </span>
+                      <span className="mt-1 text-3xl font-semibold">
+                        {formatCurrency(monthlyTotal)}
+                      </span>
+                      <span className="mt-1 text-xs capitalize text-white/80">{monthText}</span>
+                    </div>
+                  }
+                />
+              ) : (
+                <div className="flex h-[220px] w-[220px] flex-col items-center justify-center rounded-full border border-white/30 bg-white/10 text-center text-white/80 sm:h-[260px] sm:w-[260px]">
+                  <span className="text-4xl">📊</span>
+                  <p className="mt-2 text-sm font-medium">Sin datos por ahora</p>
+                  <p className="mt-1 text-xs text-white/70">Agrega tu primer gasto</p>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => setShowExpenseForm(true)}
+                className="absolute bottom-4 right-[22%] flex h-12 w-12 items-center justify-center rounded-full bg-white text-sky-600 shadow-lg transition hover:scale-105"
+              >
+                <Plus className="h-6 w-6" />
+                <span className="sr-only">Agregar gasto</span>
+              </button>
+            </div>
+
+            <MonthNavigator
+              selectedMonth={selectedMonth}
+              onMonthChange={setSelectedMonth}
+              variant="translucent"
+              className="w-full border-white/30"
+            />
+          </div>
+        </div>
       </section>
 
-      <MonthNavigator selectedMonth={selectedMonth} onMonthChange={setSelectedMonth} />
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-sky-600">
+              Resumen
+            </p>
+            <h2 className="text-xl font-semibold text-slate-900">Movimientos del mes</h2>
+          </div>
+          <Link
+            to="/projected"
+            className="inline-flex items-center gap-2 rounded-full bg-sky-50 px-4 py-2 text-xs font-semibold text-sky-600 transition hover:bg-sky-100"
+          >
+            <Sparkles className="h-4 w-4" /> Proyección
+          </Link>
+        </div>
 
-      <section className="grid gap-4 sm:grid-cols-2 sm:gap-6">
-        <Link to="/projected" className="group">
-          <Card className="overflow-hidden border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md transition-transform group-hover:-translate-y-1 group-focus-visible:-translate-y-1">
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-sm font-medium">
-                <TrendingUp size={16} />
-                Total del mes
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-1">
-              <p className="text-3xl font-semibold leading-tight">{formatCurrency(monthlyTotal)}</p>
-              <p className="text-xs uppercase tracking-wide text-blue-100">
-                {currentMonth
-                  ? "Mes actual"
-                  : selectedMonth.toLocaleDateString("es", { month: "long", year: "numeric" })}
+        <div className="rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-slate-600">Gasto total</p>
+              <p className="text-2xl font-semibold text-slate-900">{formatCurrency(monthlyTotal)}</p>
+            </div>
+            <div className="rounded-2xl bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+              {categoriesWithTotals.length} categorías
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl bg-sky-50/70 p-4 text-sky-600">
+              <p className="text-xs font-semibold uppercase tracking-wide">Promedio diario</p>
+              <p className="mt-2 text-lg font-semibold">
+                {monthlyExpenses.length > 0
+                  ? formatCurrency(monthlyTotal / new Date(selectedMonth.getFullYear(), selectedMonth.getMonth() + 1, 0).getDate())
+                  : formatCurrency(0)}
               </p>
-            </CardContent>
-          </Card>
-        </Link>
+            </div>
+            <div className="rounded-2xl bg-emerald-50/70 p-4 text-emerald-600">
+              <p className="text-xs font-semibold uppercase tracking-wide">Categoría destacada</p>
+              <p className="mt-2 text-lg font-semibold">
+                {categoriesWithTotals[0]?.name ?? "Sin datos"}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
 
-        <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <PieChart size={18} className="text-blue-600" />
-              Categorías
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <CategoryList categories={categoriesWithTotals} />
-          </CardContent>
-        </Card>
+      <section className="space-y-4">
+        <div className="rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className="flex items-center gap-2 text-base font-semibold text-slate-900">
+              <Calendar className="h-5 w-5 text-sky-500" /> Categorías del mes
+            </h3>
+            <span className="text-xs font-medium text-slate-500">
+              {formatCurrency(totalCategoriesAmount)} totales
+            </span>
+          </div>
+          <CategoryList categories={categoriesWithTotals} />
+        </div>
 
         {monthlyExpenses.length > 0 && (
-          <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur sm:col-span-2">
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-base">
-                <PieChart size={18} className="text-blue-600" />
-                Distribución por categoría
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="pt-0">
-              <ExpenseChart expenses={monthlyExpenses} />
-            </CardContent>
-          </Card>
+          <div className="rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="flex items-center gap-2 text-base font-semibold text-slate-900">
+                <Clock className="h-5 w-5 text-sky-500" /> Gastos recientes
+              </h3>
+              <span className="text-xs font-medium text-slate-500">
+                {monthlyExpenses.length} movimientos
+              </span>
+            </div>
+            <div className="space-y-3">
+              {monthlyExpenses.slice(0, 5).map((expense) => (
+                <button
+                  key={expense.id}
+                  onClick={() => setEditingExpense(expense)}
+                  className="flex w-full items-center justify-between rounded-2xl border border-slate-100 bg-slate-50/60 p-3 text-left transition hover:bg-slate-50"
+                >
+                  <div className="flex-1 pr-4">
+                    <p className="font-medium text-slate-900">{expense.description}</p>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                      <Badge variant="secondary">{expense.category}</Badge>
+                      <span>{new Date(expense.date).toLocaleDateString("es")}</span>
+                    </div>
+                  </div>
+                  <div className="text-right text-lg font-semibold text-slate-900">
+                    {formatCurrency(expense.amount)}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {monthlyExpenses.length === 0 && (
+          <div className="rounded-3xl border border-dashed border-slate-200 bg-white/70 p-10 text-center shadow-sm">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-sky-50 text-sky-500">
+              <Plus className="h-6 w-6" />
+            </div>
+            <h3 className="mt-4 text-lg font-semibold text-slate-900">
+              No hay gastos registrados
+            </h3>
+            <p className="mt-2 text-sm text-slate-500">
+              Comienza agregando tu primer gasto del mes para ver el resumen.
+            </p>
+          </div>
         )}
       </section>
 
-      {monthlyExpenses.length > 0 && (
-        <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Calendar size={18} className="text-blue-600" />
-              Gastos recientes ({monthlyExpenses.length})
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {monthlyExpenses.slice(0, 5).map((expense) => (
-              <button
-                key={expense.id}
-                onClick={() => setEditingExpense(expense)}
-                className="flex w-full items-center justify-between rounded-xl border border-blue-100 bg-blue-50/50 p-3 text-left transition-colors hover:bg-blue-50"
-              >
-                <div className="flex-1 pr-4">
-                  <p className="font-medium text-slate-900">{expense.description}</p>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                    <Badge variant="secondary">{expense.category}</Badge>
-                    <span>{new Date(expense.date).toLocaleDateString("es")}</span>
-                  </div>
-                </div>
-                <div className="text-right text-lg font-semibold text-slate-900">
-                  {formatCurrency(expense.amount)}
-                </div>
-              </button>
-            ))}
-          </CardContent>
-        </Card>
-      )}
-
-      {monthlyExpenses.length === 0 && (
-        <Card className="border border-blue-100 bg-white/90 py-12 text-center shadow-sm backdrop-blur">
-          <CardContent className="space-y-3">
-            <DollarSign size={48} className="mx-auto text-blue-200" />
-            <h3 className="text-lg font-medium text-slate-900">No hay gastos registrados</h3>
-            <p className="text-sm text-slate-500">Comienza agregando tu primer gasto del mes.</p>
-          </CardContent>
-        </Card>
-      )}
-
-      <FloatingExpenseButton />
+      <ExpenseForm open={showExpenseForm} onClose={() => setShowExpenseForm(false)} />
 
       {editingExpense && (
         <EditExpenseModal


### PR DESCRIPTION
## Summary
- redesign the home dashboard with a mobile-first layout that mirrors the provided UI, including timeframe selector, chart state, summary metrics, category insights and recent activity cards
- refresh category list styling and extend shared components (expense chart and month navigator) to support the new presentation while integrating an inline expense form trigger
- expand the side menu to surface every available section and add a dedicated sign-out action on both desktop and mobile drawers

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d53678a5cc8330b78b44e08aad04fc