### PR TITLE
Refine dashboard styling and remove timeframe filters

### DIFF
--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import { ArrowLeft, Calendar, DollarSign } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useParams, Link, useNavigate } from "react-router-dom";
@@ -15,6 +14,7 @@ const CategoryDetail = () => {
   const { expenses, categories, updateExpense } = useExpenseStore();
 
   const selectedMonth = new Date();
+  const monthText = selectedMonth.toLocaleDateString("es", { month: "long", year: "numeric" });
 
   const categoryInfo = categories.find((cat) => cat.name === category);
   const categoryExpenses = expenses.filter(
@@ -25,120 +25,140 @@ const CategoryDetail = () => {
   );
 
   const totalAmount = categoryExpenses.reduce((sum, expense) => sum + expense.amount, 0);
+  const expensesCount = categoryExpenses.length;
+  const averageExpense = expensesCount > 0 ? totalAmount / expensesCount : 0;
+  const lastExpenseDate = categoryExpenses.reduce<Date | null>((latest, expense) => {
+    const expenseDate = new Date(expense.date);
+    if (!latest || expenseDate.getTime() > latest.getTime()) {
+      return expenseDate;
+    }
+    return latest;
+  }, null);
 
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
 
   if (!categoryInfo) {
     return (
-      <div className="space-y-6 pb-14">
-        <Card className="border border-blue-100 bg-white/90 py-12 text-center shadow-sm backdrop-blur">
-          <CardContent className="space-y-3">
-            <h2 className="text-xl font-semibold text-slate-900">Categoría no encontrada</h2>
-            <Button onClick={() => navigate("/")}>Volver al inicio</Button>
-          </CardContent>
-        </Card>
+      <div className="space-y-6 pb-32 sm:pb-20">
+        <div className="rounded-3xl border border-slate-100 bg-white p-10 text-center shadow-sm">
+          <h2 className="text-2xl font-semibold text-slate-900">Categoría no encontrada</h2>
+          <p className="mt-2 text-sm text-slate-500">Revisa el listado de categorías disponibles e inténtalo nuevamente.</p>
+          <Button onClick={() => navigate("/")} className="mt-6">
+            Volver al inicio
+          </Button>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6 pb-14">
-      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-        <Link to="/" className="inline-flex">
-          <Button variant="outline" size="icon" className="h-10 w-10 rounded-full">
-            <ArrowLeft size={20} />
-          </Button>
-        </Link>
-        <div className="flex items-center gap-3">
-          <span
-            className="flex h-10 w-10 items-center justify-center rounded-full text-lg"
-            style={{ backgroundColor: categoryInfo.color }}
-          >
-            {categoryInfo.icon}
-          </span>
-          <div className="flex flex-col gap-1">
-            <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
-              Gastos por categoría
-            </p>
-            <h1 className="text-2xl font-bold text-slate-900 sm:text-3xl">{categoryInfo.name}</h1>
-            <p className="text-sm text-slate-600">
-              Gastos de {selectedMonth.toLocaleDateString("es", { month: "long", year: "numeric" })}
-            </p>
+    <div className="space-y-6 pb-32 sm:pb-20">
+      <section className="space-y-4">
+        <div className="rounded-3xl bg-gradient-to-br from-indigo-500 via-violet-500 to-sky-500 p-5 text-white shadow-xl">
+          <div className="flex items-center justify-between gap-3">
+            <Link
+              to="/"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/20 text-white transition hover:bg-white/30"
+            >
+              <ArrowLeft className="h-5 w-5" />
+              <span className="sr-only">Volver al inicio</span>
+            </Link>
+            <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white">
+              Categoría
+            </span>
+          </div>
+
+          <div className="mt-4 flex items-start gap-3">
+            <span
+              className="flex h-12 w-12 items-center justify-center rounded-2xl text-xl"
+              style={{ backgroundColor: categoryInfo.color }}
+            >
+              {categoryInfo.icon}
+            </span>
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">Gastos por categoría</p>
+              <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{categoryInfo.name}</h1>
+              <p className="text-sm capitalize text-white/80">{monthText}</p>
+              <p className="text-xs text-white/70">
+                {expensesCount} {expensesCount === 1 ? "gasto" : "gastos"} registrados este mes
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Total del mes</p>
+              <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(totalAmount)}</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Promedio por gasto</p>
+              <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(averageExpense)}</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4 sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Última compra</p>
+              <p className="mt-2 text-lg font-semibold text-white">
+                {lastExpenseDate ? lastExpenseDate.toLocaleDateString("es") : "Sin datos"}
+              </p>
+            </div>
           </div>
         </div>
       </section>
 
-      <Card className="border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md">
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2 text-sm font-medium">
-            <DollarSign size={16} />
-            Total en {categoryInfo.name}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-1">
-          <p className="text-3xl font-semibold leading-tight">{formatCurrency(totalAmount)}</p>
-          <p className="text-xs uppercase tracking-wide text-blue-100">
-            {categoryExpenses.length} {categoryExpenses.length === 1 ? "gasto" : "gastos"} registrados
-          </p>
-        </CardContent>
-      </Card>
+      <section className="space-y-4">
+        <div className="rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="flex items-center gap-2 text-base font-semibold text-slate-900">
+              <Calendar className="h-5 w-5 text-sky-500" /> Detalle de gastos
+            </h2>
+            <span className="text-xs font-medium text-slate-500">
+              {expensesCount} {expensesCount === 1 ? "gasto" : "gastos"}
+            </span>
+          </div>
 
-      <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Calendar className="text-blue-600" size={20} />
-            Detalle de gastos
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
           {categoryExpenses.length === 0 ? (
-            <div className="py-8 text-center text-sm text-slate-500">
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-10 text-center text-slate-500">
               <div className="mb-2 text-3xl">{categoryInfo.icon}</div>
               <p>No hay gastos registrados en esta categoría para este mes.</p>
             </div>
           ) : (
-            categoryExpenses
-              .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-              .map((expense) => (
-                <div
-                  key={expense.id}
-                  className="flex items-start justify-between gap-3 rounded-xl border border-blue-100 bg-blue-50/40 p-4"
-                >
-                  <div className="flex-1 space-y-1">
-                    <p className="font-medium text-slate-900">{expense.description}</p>
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                      <span className="flex items-center gap-1">
-                        <Calendar size={14} />
-                        {new Date(expense.date).toLocaleDateString("es")}
-                      </span>
+            <div className="space-y-3">
+              {categoryExpenses
+                .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+                .map((expense) => (
+                  <button
+                    key={expense.id}
+                    onClick={() => setEditingExpense(expense)}
+                    className="flex w-full items-start justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50/60 p-4 text-left transition hover:bg-slate-50"
+                  >
+                    <div className="flex-1 space-y-1">
+                      <p className="font-medium text-slate-900">{expense.description}</p>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                        <span className="flex items-center gap-1">
+                          <Calendar size={14} />
+                          {new Date(expense.date).toLocaleDateString("es")}
+                        </span>
+                        {expense.installments && (
+                          <Badge variant="outline" className="text-xs">
+                            Cuota {expense.installments.current}/{expense.installments.total}
+                          </Badge>
+                        )}
+                      </div>
                       {expense.installments && (
-                        <Badge variant="outline" className="text-xs">
-                          Cuota {expense.installments.current}/{expense.installments.total}
-                        </Badge>
+                        <p className="text-xs text-slate-400">
+                          Total original: {formatCurrency(expense.installments.originalAmount)}
+                        </p>
                       )}
                     </div>
-                    {expense.installments && (
-                      <p className="text-xs text-slate-400">
-                        Total original: {formatCurrency(expense.installments.originalAmount)}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex flex-col items-end gap-2">
-                    <button
-                      onClick={() => setEditingExpense(expense)}
-                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                    >
-                      Editar
-                    </button>
-                    <p className="text-lg font-semibold text-slate-900">
-                      {formatCurrency(expense.amount)}
-                    </p>
-                  </div>
-                </div>
-              ))
+                    <div className="flex flex-col items-end gap-2">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Editar</span>
+                      <p className="text-lg font-semibold text-slate-900">{formatCurrency(expense.amount)}</p>
+                    </div>
+                  </button>
+                ))}
+            </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </section>
 
       {editingExpense && (
         <EditExpenseModal

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,6 @@ import { ExpenseForm } from "@/components/ExpenseForm";
 
 const Index = () => {
   const [selectedMonth, setSelectedMonth] = useState(new Date());
-  const [selectedRange, setSelectedRange] = useState("Mes");
   const [showExpenseForm, setShowExpenseForm] = useState(false);
   const { getExpensesForMonth, getTotalForMonth, getCategoriesWithTotals, updateExpense } = useExpenseStore();
 
@@ -32,7 +31,7 @@ const Index = () => {
     year: "numeric",
   });
 
-  const timeframeOptions = ["Día", "Semana", "Mes", "Año", "Período"];
+  const summaryLabel = "Total mensual";
 
   return (
     <div className="space-y-6 pb-32 sm:pb-20">
@@ -51,23 +50,6 @@ const Index = () => {
             <p className="text-xs text-white/70">Controla tus finanzas día a día.</p>
           </div>
 
-          <div className="mt-5 flex items-center gap-2 overflow-x-auto pb-1">
-            {timeframeOptions.map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => setSelectedRange(option)}
-                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition ${
-                  selectedRange === option
-                    ? "bg-white text-sky-600 shadow-sm"
-                    : "bg-white/10 text-white/80 hover:bg-white/20"
-                }`}
-              >
-                {option}
-              </button>
-            ))}
-          </div>
-
           <div className="mt-6 flex flex-col items-center gap-6">
             <div className="relative flex w-full justify-center">
               {monthlyExpenses.length > 0 ? (
@@ -79,7 +61,7 @@ const Index = () => {
                   centerLabel={
                     <div className="flex flex-col items-center text-white">
                       <span className="text-xs uppercase tracking-[0.25em] text-white/70">
-                        {selectedRange}
+                        {summaryLabel}
                       </span>
                       <span className="mt-1 text-3xl font-semibold">
                         {formatCurrency(monthlyTotal)}

--- a/src/pages/MonthDetail.tsx
+++ b/src/pages/MonthDetail.tsx
@@ -1,5 +1,4 @@
-import { ArrowLeft, Calendar, DollarSign, TrendingUp } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowLeft, Calendar, TrendingUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { useExpenseStore } from "@/hooks/useExpenseStore";
@@ -14,15 +13,14 @@ const MonthDetail = () => {
 
   if (!year || !month) {
     return (
-      <div className="space-y-6 pb-14">
-        <Card className="border border-blue-100 bg-white/90 py-12 text-center shadow-sm backdrop-blur">
-          <CardContent className="space-y-3">
-            <h2 className="text-xl font-semibold text-slate-900">Mes no válido</h2>
-            <Button onClick={() => navigate("/projected")} className="mt-2">
-              Volver a gastos proyectados
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="space-y-6 pb-32 sm:pb-20">
+        <div className="rounded-3xl border border-slate-100 bg-white p-10 text-center shadow-sm">
+          <h2 className="text-2xl font-semibold text-slate-900">Mes no válido</h2>
+          <p className="mt-2 text-sm text-slate-500">Selecciona un período disponible en la proyección.</p>
+          <Button onClick={() => navigate("/projected")} className="mt-6">
+            Volver a gastos proyectados
+          </Button>
+        </div>
       </div>
     );
   }
@@ -30,60 +28,77 @@ const MonthDetail = () => {
   const selectedDate = new Date(parseInt(year), parseInt(month) - 1, 1);
   const totalAmount = getTotalForMonth(selectedDate);
   const categoriesWithTotals = getCategoriesWithTotals(selectedDate);
+  const monthText = formatMonth(selectedDate);
+  const categoriesCount = categoriesWithTotals.length;
+  const daysInMonth = new Date(selectedDate.getFullYear(), selectedDate.getMonth() + 1, 0).getDate();
+  const dailyAverage = daysInMonth > 0 ? totalAmount / daysInMonth : 0;
+  const topCategory =
+    categoriesWithTotals.length > 0
+      ? categoriesWithTotals.reduce((prev, current) => (current.total > prev.total ? current : prev), categoriesWithTotals[0])
+      : null;
 
   return (
-    <div className="space-y-6 pb-14">
-      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-        <Link to="/projected" className="inline-flex">
-          <Button variant="outline" size="icon" className="h-10 w-10 rounded-full">
-            <ArrowLeft size={20} />
-          </Button>
-        </Link>
-        <div className="flex flex-col gap-1">
-          <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
-            Resumen mensual
-          </p>
-          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-900 sm:text-3xl">
-            <Calendar className="text-blue-600" />
-            {formatMonth(selectedDate)}
-          </h1>
-          <p className="text-sm text-slate-600">Desglose detallado de gastos.</p>
+    <div className="space-y-6 pb-32 sm:pb-20">
+      <section className="space-y-4">
+        <div className="rounded-3xl bg-gradient-to-br from-sky-500 via-blue-500 to-indigo-600 p-5 text-white shadow-xl">
+          <div className="flex items-center justify-between gap-3">
+            <Link
+              to="/projected"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/20 text-white transition hover:bg-white/30"
+            >
+              <ArrowLeft className="h-5 w-5" />
+              <span className="sr-only">Volver a proyección</span>
+            </Link>
+            <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white">
+              Mes
+            </span>
+          </div>
+
+          <div className="mt-4 space-y-1">
+            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+              <Calendar className="h-4 w-4" />
+              Resumen mensual
+            </p>
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">{formatCurrency(totalAmount)}</h1>
+            <p className="text-sm capitalize text-white/80">{monthText}</p>
+            <p className="text-xs text-white/70">
+              {categoriesCount} {categoriesCount === 1 ? "categoría" : "categorías"} con gastos registrados
+            </p>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Promedio diario</p>
+              <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(dailyAverage)}</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/70">Categoría destacada</p>
+              <p className="mt-2 text-lg font-semibold text-white">{topCategory?.name ?? "Sin datos"}</p>
+            </div>
+          </div>
         </div>
       </section>
 
-      <Card className="border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md">
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2 text-sm font-medium">
-            <DollarSign size={16} />
-            Total del mes
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-1">
-          <p className="text-3xl font-semibold leading-tight">{formatCurrency(totalAmount)}</p>
-          <p className="text-xs uppercase tracking-wide text-blue-100">
-            {categoriesWithTotals.length} {categoriesWithTotals.length === 1 ? "categoría" : "categorías"} con gastos
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <TrendingUp className="text-blue-600" size={20} />
-            Gastos por categoría
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="pt-0">
+      <section className="space-y-4">
+        <div className="rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="flex items-center gap-2 text-base font-semibold text-slate-900">
+              <TrendingUp className="h-5 w-5 text-sky-500" /> Gastos por categoría
+            </h2>
+            <span className="text-xs font-medium text-slate-500">
+              {categoriesCount} {categoriesCount === 1 ? "categoría" : "categorías"}
+            </span>
+          </div>
           {categoriesWithTotals.length === 0 ? (
-            <div className="py-8 text-center text-sm text-slate-500">
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-10 text-center text-slate-500">
               <div className="mb-2 text-3xl">📊</div>
               <p>No hay gastos registrados en este mes.</p>
             </div>
           ) : (
             <CategoryList categories={categoriesWithTotals} />
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </section>
 
       <FloatingExpenseButton />
     </div>

--- a/src/pages/ProjectedExpenses.tsx
+++ b/src/pages/ProjectedExpenses.tsx
@@ -1,6 +1,4 @@
 import { ArrowLeft, Calendar, TrendingUp, TrendingDown } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useExpenseStore } from "@/hooks/useExpenseStore";
 import { formatCurrency, formatMonth } from "@/lib/formatters";
@@ -42,117 +40,105 @@ const ProjectedExpenses = () => {
   const currentTotal = monthsData.find((m) => m.isCurrent)?.total || 0;
 
   return (
-    <div className="space-y-6 pb-14">
-      <section className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-        <Link to="/" className="inline-flex">
-          <Button variant="outline" size="icon" className="h-10 w-10 rounded-full">
-            <ArrowLeft size={20} />
-          </Button>
-        </Link>
-        <div className="flex flex-col gap-1">
-          <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
-            Proyección
-          </p>
-          <h1 className="flex items-center gap-2 text-2xl font-bold text-slate-900 sm:text-3xl">
-            <Calendar className="text-blue-600" />
-            Gastos proyectados
-          </h1>
-          <p className="text-sm text-slate-600">
-            Vista global de todos tus gastos por mes.
-          </p>
+    <div className="space-y-6 pb-32 sm:pb-20">
+      <section className="space-y-4">
+        <div className="rounded-3xl bg-gradient-to-br from-violet-500 via-sky-500 to-emerald-500 p-5 text-white shadow-xl">
+          <div className="flex items-center justify-between gap-3">
+            <Link
+              to="/"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/20 text-white transition hover:bg-white/30"
+            >
+              <ArrowLeft className="h-5 w-5" />
+              <span className="sr-only">Volver al inicio</span>
+            </Link>
+            <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white">
+              Proyección
+            </span>
+          </div>
+
+          <div className="mt-4 space-y-1">
+            <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+              <Calendar className="h-4 w-4" />
+              Resumen de 12 meses
+            </p>
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">Gastos proyectados</h1>
+            <p className="text-sm text-white/80">Planifica y compara tus gastos pasados, actuales y futuros.</p>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-white/70">
+                <TrendingDown className="h-4 w-4" /> Gastos pasados
+              </p>
+              <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(totalPast)}</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-white/70">
+                <Calendar className="h-4 w-4" /> Mes actual
+              </p>
+              <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(currentTotal)}</p>
+            </div>
+            <div className="rounded-2xl bg-white/15 p-4">
+              <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-white/70">
+                <TrendingUp className="h-4 w-4" /> Gastos futuros
+              </p>
+              <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(totalFuture)}</p>
+            </div>
+          </div>
         </div>
       </section>
 
-      <section className="grid gap-4 sm:grid-cols-3 sm:gap-6">
-        <Card className="border-none bg-gradient-to-r from-red-500 to-red-600 text-white shadow-md">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
-              <TrendingDown size={16} />
-              Gastos pasados
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-semibold">{formatCurrency(totalPast)}</p>
-          </CardContent>
-        </Card>
+      <section className="space-y-4">
+        <div className="rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-base font-semibold text-slate-900">Desglose mensual</h2>
+            <span className="text-xs font-medium text-slate-500">{monthsData.length} meses</span>
+          </div>
 
-        <Card className="border-none bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-md">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">Mes actual</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-semibold">{formatCurrency(currentTotal)}</p>
-          </CardContent>
-        </Card>
-
-        <Card className="border-none bg-gradient-to-r from-green-500 to-green-600 text-white shadow-md">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium">
-              <TrendingUp size={16} />
-              Gastos futuros
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-2xl font-semibold">{formatCurrency(totalFuture)}</p>
-          </CardContent>
-        </Card>
-      </section>
-
-      <Card className="border border-blue-100 bg-white/90 shadow-sm backdrop-blur">
-        <CardHeader>
-          <CardTitle className="text-base font-semibold">Desglose mensual</CardTitle>
-        </CardHeader>
-        <CardContent>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {monthsData.map((monthData) => {
               const { date, total, isPast, isCurrent, isFuture, hasExpenses } = monthData;
 
-              let cardClass = "bg-blue-50/40 border-blue-100";
+              let cardClass = "border-slate-100 bg-slate-50/60";
               let badgeVariant: "default" | "secondary" | "destructive" = "secondary";
-              let statusText = "";
+              let statusText = "Planificado";
 
               if (isCurrent) {
-                cardClass = "bg-blue-100/60 border-blue-300";
+                cardClass = "border-sky-200 bg-sky-50/80";
                 badgeVariant = "default";
                 statusText = "Actual";
               } else if (isPast) {
-                cardClass = hasExpenses ? "bg-red-50/60 border-red-200" : "bg-blue-50/40 border-blue-100";
-                statusText = "Pasado";
+                cardClass = hasExpenses ? "border-rose-200 bg-rose-50/80" : "border-slate-100 bg-slate-50/60";
+                badgeVariant = hasExpenses ? "destructive" : "secondary";
+                statusText = hasExpenses ? "Pasado" : "Sin datos";
               } else if (isFuture) {
-                cardClass = hasExpenses ? "bg-green-50/60 border-green-200" : "bg-blue-50/40 border-blue-100";
-                statusText = "Futuro";
+                cardClass = hasExpenses ? "border-emerald-200 bg-emerald-50/80" : "border-slate-100 bg-slate-50/60";
+                badgeVariant = hasExpenses ? "default" : "secondary";
+                statusText = hasExpenses ? "Futuro" : "Planificado";
               }
 
               return (
-                <Link
-                  key={date.toISOString()}
-                  to={`/month/${date.getFullYear()}/${date.getMonth() + 1}`}
-                  className="block"
-                >
+                <Link key={date.toISOString()} to={`/month/${date.getFullYear()}/${date.getMonth() + 1}`} className="block">
                   <div
-                    className={`rounded-xl border p-4 transition-transform hover:-translate-y-1 hover:shadow-md ${cardClass}`}
+                    className={`rounded-2xl border p-4 transition-transform hover:-translate-y-1 hover:shadow-md ${cardClass}`}
                   >
                     <div className="mb-2 flex items-center justify-between">
-                      <h3 className="text-base font-medium capitalize text-slate-900">
-                        {formatMonth(date)}
-                      </h3>
+                      <h3 className="text-base font-medium capitalize text-slate-900">{formatMonth(date)}</h3>
                       <Badge variant={badgeVariant} className="text-xs">
                         {statusText}
                       </Badge>
                     </div>
-                    <p className="text-lg font-semibold text-slate-900">
-                      {formatCurrency(total)}
-                    </p>
+                    <p className="text-lg font-semibold text-slate-900">{formatCurrency(total)}</p>
                     {!hasExpenses && (
-                      <p className="mt-1 text-xs text-slate-500">Sin gastos</p>
+                      <p className="mt-1 text-xs text-slate-500">Sin gastos registrados</p>
                     )}
                   </div>
                 </Link>
               );
             })}
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </section>
 
       <FloatingExpenseButton />
     </div>


### PR DESCRIPTION
## Summary
- remove the timeframe toggle from the home dashboard and replace the chart label with a static monthly summary tag
- restyle the month, category, and projection detail pages to mirror the gradient hero and card layout used on the homepage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5408a1cc48330a7a2e974b89e69f9