### PR TITLE
Add global floating expense button

### DIFF
--- a/src/components/FloatingExpenseButton.tsx
+++ b/src/components/FloatingExpenseButton.tsx
@@ -1,8 +1,8 @@
 
-import { useState } from 'react';
-import { Plus } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { ExpenseForm } from '@/components/ExpenseForm';
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ExpenseForm } from "@/components/ExpenseForm";
 
 export const FloatingExpenseButton = () => {
   const [showExpenseForm, setShowExpenseForm] = useState(false);
@@ -11,13 +11,14 @@ export const FloatingExpenseButton = () => {
     <>
       <Button
         onClick={() => setShowExpenseForm(true)}
-        className="fixed bottom-24 right-5 z-50 h-14 w-14 rounded-full bg-gradient-to-r from-blue-500 to-blue-600 shadow-lg hover:from-blue-600 hover:to-blue-700 sm:bottom-8 sm:right-8"
+        className="fixed bottom-6 left-4 z-50 h-14 w-14 rounded-full bg-gradient-to-r from-blue-500 to-blue-600 text-white shadow-lg transition hover:from-blue-600 hover:to-blue-700 sm:bottom-8 sm:left-8"
         size="icon"
       >
         <Plus size={24} />
+        <span className="sr-only">Agregar gasto</span>
       </Button>
 
-      <ExpenseForm 
+      <ExpenseForm
         open={showExpenseForm}
         onClose={() => setShowExpenseForm(false)}
       />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, Link } from "react-router-dom";
 import { PiggyBank } from "lucide-react";
 import SideMenu from "@/components/SideMenu";
+import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 
 export function Layout() {
   return (
@@ -27,6 +28,7 @@ export function Layout() {
         <main className="flex-1 px-4 pb-28 pt-6 sm:px-6">
           <Outlet />
         </main>
+        <FloatingExpenseButton />
       </div>
     </div>
   );

--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -5,7 +5,6 @@ import { Badge } from "@/components/ui/badge";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { Expense, useExpenseStore } from "@/hooks/useExpenseStore";
 import { formatCurrency } from "@/lib/formatters";
-import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 import { EditExpenseModal } from "@/components/EditExpenseModal";
 
 const CategoryDetail = () => {
@@ -171,7 +170,6 @@ const CategoryDetail = () => {
         />
       )}
 
-      <FloatingExpenseButton />
     </div>
   );
 };

--- a/src/pages/MonthDetail.tsx
+++ b/src/pages/MonthDetail.tsx
@@ -4,7 +4,6 @@ import { useParams, Link, useNavigate } from "react-router-dom";
 import { useExpenseStore } from "@/hooks/useExpenseStore";
 import { formatCurrency, formatMonth } from "@/lib/formatters";
 import { CategoryList } from "@/components/CategoryList";
-import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 
 const MonthDetail = () => {
   const { year, month } = useParams<{ year: string; month: string }>();
@@ -100,7 +99,6 @@ const MonthDetail = () => {
         </div>
       </section>
 
-      <FloatingExpenseButton />
     </div>
   );
 };

--- a/src/pages/ProjectedExpenses.tsx
+++ b/src/pages/ProjectedExpenses.tsx
@@ -3,7 +3,6 @@ import { Badge } from "@/components/ui/badge";
 import { useExpenseStore } from "@/hooks/useExpenseStore";
 import { formatCurrency, formatMonth } from "@/lib/formatters";
 import { Link } from "react-router-dom";
-import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 
 const ProjectedExpenses = () => {
   const { getTotalForMonth } = useExpenseStore();
@@ -140,7 +139,6 @@ const ProjectedExpenses = () => {
         </div>
       </section>
 
-      <FloatingExpenseButton />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- reposition the floating expense button so it stays fixed in the lower-left corner with accessible labeling
- render the floating expense trigger from the shared layout to make it available across the private area
- remove page-level floating button instances that are now redundant

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d54875a5a48330b07eafbc18ab2994