### PR TITLE
Add scroll restoration on route change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import PrivateRoute from "./components/PrivateRoute";
 import { AuthProvider } from "@/hooks/useAuth";
 import { ExpenseProvider } from "@/hooks/useExpenseStore";
 import Layout from "@/components/Layout";
+import ScrollToTop from "@/components/ScrollToTop";
 import AddExpense from "./pages/AddExpense";
 
 const queryClient = new QueryClient();
@@ -26,6 +27,7 @@ const App = () => (
           <Toaster />
           <Sonner />
           <BrowserRouter>
+            <ScrollToTop />
             <Routes>
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## Summary
- create a ScrollToTop helper component that scrolls to the top whenever the location changes
- register ScrollToTop inside the BrowserRouter so navigation returns the user to the top of the page by default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d54dec0e148330aefb73cc1f6ece2c