### PR TITLE
Format currency inputs with locale separators

### DIFF
--- a/src/components/EditExpenseModal.tsx
+++ b/src/components/EditExpenseModal.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { formatCurrencyInput, parseCurrencyInput } from '@/lib/formatters';
 
 interface Expense {
   id: string;
@@ -23,7 +24,7 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
   onSave,
   onClose,
 }) => {
-  const [amount, setAmount] = useState(expense.amount.toString());
+  const [amount, setAmount] = useState(formatCurrencyInput(expense.amount.toFixed(2)));
   const [category, setCategory] = useState(expense.category);
   const [description, setDescription] = useState(expense.description);
   const [date, setDate] = useState(expense.date);
@@ -31,7 +32,7 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     onSave({
-      amount: parseFloat(amount),
+      amount: parseCurrencyInput(amount),
       category,
       description,
       date,
@@ -53,13 +54,12 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
               <Label htmlFor="amount">Monto</Label>
               <Input
                 id="amount"
-                type="number"
-                step="0.01"
-                min="0"
+                type="text"
+                inputMode="decimal"
                 value={amount}
-                onChange={(e) => setAmount(e.target.value)}
+                onChange={(e) => setAmount(formatCurrencyInput(e.target.value))}
                 required
-                placeholder="Ejemplo: 150.50"
+                placeholder="Ejemplo: 150,50"
               />
             </div>
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -3,9 +3,60 @@ export const formatCurrency = (amount: number): string => {
   return new Intl.NumberFormat('es-AR', {
     style: 'currency',
     currency: 'ARS',
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(amount);
+};
+
+const THOUSANDS_REGEX = /\B(?=(\d{3})+(?!\d))/g;
+
+export const formatCurrencyInput = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  const cleanedValue = value.replace(/[^\d.,]/g, '');
+
+  if (!cleanedValue) {
+    return '';
+  }
+
+  const lastSeparatorIndex = Math.max(
+    cleanedValue.lastIndexOf(','),
+    cleanedValue.lastIndexOf('.')
+  );
+
+  let integerPart = cleanedValue;
+  let decimalPart = '';
+
+  if (lastSeparatorIndex !== -1) {
+    integerPart = cleanedValue.slice(0, lastSeparatorIndex);
+    decimalPart = cleanedValue.slice(lastSeparatorIndex + 1);
+  }
+
+  const normalizedInteger = integerPart.replace(/[.,]/g, '').replace(/^0+(?=\d)/, '');
+  const formattedInteger = (normalizedInteger || '0').replace(THOUSANDS_REGEX, '.');
+
+  const normalizedDecimal = decimalPart.replace(/\D/g, '').slice(0, 2);
+
+  if (normalizedDecimal) {
+    return `${formattedInteger},${normalizedDecimal}`;
+  }
+
+  if (lastSeparatorIndex === cleanedValue.length - 1 && lastSeparatorIndex !== -1) {
+    return `${formattedInteger},`;
+  }
+
+  return formattedInteger;
+};
+
+export const parseCurrencyInput = (value: string): number => {
+  if (!value) {
+    return Number.NaN;
+  }
+
+  const normalizedValue = value.replace(/\./g, '').replace(',', '.');
+  return parseFloat(normalizedValue);
 };
 
 export const formatDate = (date: string | Date): string => {

--- a/src/pages/AddExpense.tsx
+++ b/src/pages/AddExpense.tsx
@@ -11,6 +11,7 @@ import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useExpenseStore } from "@/hooks/useExpenseStore";
 import { useToast } from "@/hooks/use-toast";
+import { formatCurrency, formatCurrencyInput, parseCurrencyInput } from "@/lib/formatters";
 
 const formatDateLabel = (date: Date) =>
   date.toLocaleDateString("es", {
@@ -45,6 +46,17 @@ const AddExpense = () => {
     });
   }, []);
 
+  const parsedAmount = parseCurrencyInput(amount);
+  const hasAmountValue = amount !== "";
+  const installmentsNumber = parseInt(installmentCount, 10);
+  const installmentPreview =
+    hasAmountValue &&
+    !Number.isNaN(parsedAmount) &&
+    !Number.isNaN(installmentsNumber) &&
+    installmentsNumber > 0
+      ? formatCurrency(parsedAmount / installmentsNumber)
+      : null;
+
   const resetForm = () => {
     setAmount("");
     setCategory(null);
@@ -66,7 +78,7 @@ const AddExpense = () => {
       return;
     }
 
-    const numericAmount = parseFloat(amount);
+    const numericAmount = parseCurrencyInput(amount);
     if (Number.isNaN(numericAmount) || numericAmount <= 0) {
       toast({
         title: "Monto inválido",
@@ -77,8 +89,11 @@ const AddExpense = () => {
     }
 
     if (hasInstallments) {
-      const installments = parseInt(installmentCount, 10);
-      if (installments < 2 || installments > 60) {
+      if (
+        Number.isNaN(installmentsNumber) ||
+        installmentsNumber < 2 ||
+        installmentsNumber > 60
+      ) {
         toast({
           title: "Cuotas inválidas",
           description: "El número de cuotas debe estar entre 2 y 60",
@@ -91,13 +106,13 @@ const AddExpense = () => {
         numericAmount,
         category,
         description,
-        installments,
+        installmentsNumber,
         new Date(date)
       );
 
       toast({
         title: "Gasto agregado",
-        description: `Distribuido en ${installments} cuotas`,
+        description: `Distribuido en ${installmentsNumber} cuotas`,
       });
     } else {
       await addExpense({
@@ -134,11 +149,11 @@ const AddExpense = () => {
           </div>
           <div className="flex items-baseline gap-2">
             <input
-              type="number"
+              type="text"
               inputMode="decimal"
               value={amount}
-              onChange={(event) => setAmount(event.target.value)}
-              placeholder="0"
+              onChange={(event) => setAmount(formatCurrencyInput(event.target.value))}
+              placeholder="0,00"
               className="w-full bg-transparent text-4xl font-semibold text-white placeholder:text-white/70 focus:outline-none"
             />
             <span className="text-sm font-semibold uppercase tracking-[0.3em] text-white/80">
@@ -281,10 +296,8 @@ const AddExpense = () => {
                   ))}
                 </SelectContent>
               </Select>
-              {amount && (
-                <p className="text-xs text-slate-500">
-                  Cuota estimada: ${(parseFloat(amount) / parseInt(installmentCount, 10)).toFixed(2)}
-                </p>
+              {installmentPreview && (
+                <p className="text-xs text-slate-500">Cuota estimada: {installmentPreview}</p>
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary
- add reusable helpers to format and parse currency values using thousand separators and decimal commas
- update the add expense flow to display localized formatting in the main amount field and installment preview
- update the edit expense modal to accept and show amounts with localized separators

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d54e2995dc8330bc8c32da6ef83d4d