### PR TITLE
Hide floating expense FAB on new expense page

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,12 @@
-import { Outlet, Link } from "react-router-dom";
+import { Outlet, Link, useLocation } from "react-router-dom";
 import { PiggyBank } from "lucide-react";
 import SideMenu from "@/components/SideMenu";
 import { FloatingExpenseButton } from "@/components/FloatingExpenseButton";
 
 export function Layout() {
+  const location = useLocation();
+  const shouldHideFloatingButton = location.pathname === "/expenses/new";
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-100">
       <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col">
@@ -28,7 +31,7 @@ export function Layout() {
         <main className="flex-1 px-4 pb-28 pt-6 sm:px-6">
           <Outlet />
         </main>
-        <FloatingExpenseButton />
+        {!shouldHideFloatingButton && <FloatingExpenseButton />}
       </div>
     </div>
   );

--- a/src/pages/AddExpense.tsx
+++ b/src/pages/AddExpense.tsx
@@ -118,7 +118,7 @@ const AddExpense = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-8 pb-16">
+    <form onSubmit={handleSubmit} className="space-y-8 pb-40">
       <div className="rounded-3xl bg-gradient-to-br from-emerald-400 via-sky-500 to-indigo-500 p-6 text-white shadow-xl">
         <button
           type="button"
@@ -291,15 +291,13 @@ const AddExpense = () => {
         </Card>
       </section>
 
-      <div className="flex gap-3">
-        <Button type="button" variant="outline" className="flex-1" onClick={() => navigate(-1)}>
-          Cancelar
-        </Button>
+      <div className="h-24" />
+      <div className="fixed inset-x-0 bottom-6 flex justify-center px-4 sm:px-6">
         <Button
           type="submit"
-          className="flex-1 rounded-full bg-gradient-to-r from-blue-500 to-blue-600 text-base font-semibold shadow-lg transition hover:from-blue-600 hover:to-blue-700"
+          className="w-full max-w-md rounded-full bg-gradient-to-r from-blue-500 to-blue-600 text-base font-semibold shadow-lg transition hover:from-blue-600 hover:to-blue-700"
         >
-          Añadir gasto
+          Guardar gasto
         </Button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- hide the global floating expense button when the new expense screen is open
- anchor the save expense action to the bottom of the form and remove the cancel button text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d54f7322308330b89ff85ead0cba2e