### PR TITLE
feat: mejorar experiencia de calendario en mobile

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,0 +1,160 @@
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { Calendar as CalendarIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar, type CalendarProps } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+
+interface DatePickerProps {
+  value?: string | null;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  buttonClassName?: string;
+  id?: string;
+  disabledDates?: CalendarProps["disabled"];
+  fromYear?: number;
+  toYear?: number;
+  weekStartsOn?: CalendarProps["weekStartsOn"];
+  captionLayout?: CalendarProps["captionLayout"];
+}
+
+const formatForInput = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const parseFromInput = (value?: string | null) => {
+  if (!value) {
+    return undefined;
+  }
+
+  const segments = value.split("-");
+  if (segments.length !== 3) {
+    return undefined;
+  }
+
+  const [year, month, day] = segments.map(Number);
+  if (!year || !month || !day) {
+    return undefined;
+  }
+
+  return new Date(year, month - 1, day);
+};
+
+export function DatePicker({
+  value,
+  onChange,
+  placeholder = "Selecciona una fecha",
+  disabled,
+  className,
+  buttonClassName,
+  id,
+  disabledDates,
+  fromYear,
+  toYear,
+  weekStartsOn = 1,
+  captionLayout = "dropdown-buttons",
+}: DatePickerProps) {
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(false);
+
+  const selectedDate = useMemo(() => parseFromInput(value), [value]);
+
+  const formattedValue = selectedDate
+    ? format(selectedDate, "EEEE d 'de' MMMM yyyy", { locale: es })
+    : placeholder;
+
+  const handleSelect: CalendarProps["onSelect"] = (date) => {
+    if (!date) {
+      return;
+    }
+
+    onChange(formatForInput(date));
+    setOpen(false);
+  };
+
+  const calendar = (
+    <Calendar
+      mode="single"
+      selected={selectedDate}
+      defaultMonth={selectedDate}
+      onSelect={handleSelect}
+      disabled={disabledDates}
+      fromYear={fromYear}
+      toYear={toYear}
+      weekStartsOn={weekStartsOn}
+      captionLayout={captionLayout}
+      initialFocus
+    />
+  );
+
+  const trigger = (
+    <Button
+      type="button"
+      variant="outline"
+      disabled={disabled}
+      id={id}
+      className={cn(
+        "h-11 w-full justify-start text-left font-normal",
+        !selectedDate && "text-muted-foreground",
+        buttonClassName
+      )}
+    >
+      <CalendarIcon className="mr-2 h-4 w-4" />
+      {formattedValue}
+    </Button>
+  );
+
+  return (
+    <div className={className}>
+      {isMobile ? (
+        <Drawer open={open} onOpenChange={setOpen}>
+          <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+          <DrawerContent className="bg-background">
+            <DrawerHeader className="text-left">
+              <DrawerTitle>Selecciona una fecha</DrawerTitle>
+              <DrawerDescription>Elige el día correspondiente a tu gasto.</DrawerDescription>
+            </DrawerHeader>
+            <div className="px-4 pb-4">
+              {calendar}
+            </div>
+            <DrawerFooter>
+              <DrawerClose asChild>
+                <Button variant="outline">Cerrar</Button>
+              </DrawerClose>
+            </DrawerFooter>
+          </DrawerContent>
+        </Drawer>
+      ) : (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            {calendar}
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/src/components/EditExpenseModal.tsx
+++ b/src/components/EditExpenseModal.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Loader2 } from 'lucide-react';
+import { DatePicker } from '@/components/DatePicker';
 
 interface Expense {
   id: string;
@@ -100,13 +101,12 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="date">Fecha</Label>
-              <Input
-                id="date"
-                type="date"
+              <Label htmlFor="edit-date">Fecha</Label>
+              <DatePicker
+                id="edit-date"
                 value={date}
-                onChange={(e) => setDate(e.target.value)}
-                required
+                onChange={setDate}
+                buttonClassName="h-10"
               />
             </div>
 

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -16,28 +16,28 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn("p-2 sm:p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        months: "flex flex-col space-y-4 sm:flex-row sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
+        caption: "flex items-center justify-center pt-1",
+        caption_label: "text-sm font-semibold sm:text-base",
+        nav: "flex items-center space-x-2",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "h-9 w-9 bg-transparent p-0 opacity-60 hover:opacity-100"
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
+        nav_button_previous: "-ml-1",
+        nav_button_next: "-mr-1",
         table: "w-full border-collapse space-y-1",
         head_row: "flex",
         head_cell:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+          "w-10 rounded-md text-[0.8rem] font-medium text-muted-foreground",
+        row: "mt-2 flex w-full",
+        cell: "relative h-10 w-10 p-0 text-center text-sm [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+          "h-10 w-10 p-0 text-base font-medium aria-selected:opacity-100 sm:text-sm"
         ),
         day_range_end: "day-range-end",
         day_selected:

--- a/src/pages/AddExpense.tsx
+++ b/src/pages/AddExpense.tsx
@@ -3,7 +3,6 @@ import { ArrowLeft, Calendar, ChevronRight } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -11,12 +10,30 @@ import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useExpenseStore } from "@/hooks/useExpenseStore";
 import { useToast } from "@/hooks/use-toast";
+import { DatePicker } from "@/components/DatePicker";
 
 const formatDateLabel = (date: Date) =>
   date.toLocaleDateString("es", {
     day: "numeric",
     month: "numeric",
   });
+
+const formatDateValue = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+
+const parseDateValue = (value: string) => {
+  const segments = value.split("-");
+  if (segments.length !== 3) {
+    return new Date();
+  }
+
+  const [year, month, day] = segments.map(Number);
+  if (!year || !month || !day) {
+    return new Date();
+  }
+
+  return new Date(year, month - 1, day);
+};
 
 const AddExpense = () => {
   const navigate = useNavigate();
@@ -28,7 +45,7 @@ const AddExpense = () => {
   const [amount, setAmount] = useState("");
   const [category, setCategory] = useState<string | null>(null);
   const [description, setDescription] = useState("");
-  const [date, setDate] = useState(() => new Date().toISOString().split("T")[0]);
+  const [date, setDate] = useState(() => formatDateValue(new Date()));
   const [hasInstallments, setHasInstallments] = useState(false);
   const [installmentCount, setInstallmentCount] = useState("2");
 
@@ -41,7 +58,7 @@ const AddExpense = () => {
     return [0, 1, 2].map((offset) => {
       const optionDate = new Date(today);
       optionDate.setDate(today.getDate() - offset);
-      const value = optionDate.toISOString().split("T")[0];
+      const value = formatDateValue(optionDate);
       return {
         value,
         label: formatDateLabel(optionDate),
@@ -55,7 +72,7 @@ const AddExpense = () => {
     setAmount("");
     setCategory(null);
     setDescription("");
-    setDate(new Date().toISOString().split("T")[0]);
+    setDate(formatDateValue(new Date()));
     setHasInstallments(false);
     setInstallmentCount("2");
   };
@@ -98,7 +115,7 @@ const AddExpense = () => {
         category,
         description,
         installments,
-        new Date(date)
+        parseDateValue(date)
       );
 
       toast({
@@ -200,7 +217,7 @@ const AddExpense = () => {
           </div>
           <div className="flex items-center gap-2 text-xs text-slate-500">
             <Calendar className="h-4 w-4" />
-            <span>{new Date(date).toLocaleDateString("es", { dateStyle: "long" })}</span>
+            <span>{parseDateValue(date).toLocaleDateString("es", { dateStyle: "long" })}</span>
           </div>
         </div>
         <div className="grid grid-cols-3 gap-3">
@@ -229,12 +246,12 @@ const AddExpense = () => {
             <Label htmlFor="date" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               Otra fecha
             </Label>
-            <Input
+            <DatePicker
               id="date"
-              type="date"
               value={date}
-              onChange={(event) => setDate(event.target.value)}
-              className="mt-1"
+              onChange={setDate}
+              buttonClassName="mt-1"
+              placeholder="Elegí una fecha"
             />
           </div>
           <ChevronRight className="h-5 w-5 text-slate-400" />


### PR DESCRIPTION
## Summary
- add a responsive date picker component that uses a drawer on mobile and a popover on desktop
- replace manual date inputs in the add and edit expense forms with the new picker and improve ISO date handling
- tweak calendar styles to increase touch targets and readability on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d550eae2048330a4784d72af1f7299