### PR TITLE
Prevent register screen flash during login

### DIFF
--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -2,9 +2,9 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 
 export const PrivateRoute = () => {
-  const { user, profile, loading } = useAuth();
+  const { user, profile, loading, profileChecked } = useAuth();
 
-  if (loading) {
+  if (loading || !profileChecked) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500">
         <div className="flex flex-col items-center gap-6 rounded-3xl bg-white/10 p-10 text-white shadow-2xl backdrop-blur-lg">

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -23,6 +23,7 @@ interface AuthContextType {
   user: User | null;
   profile: UserProfile | null;
   loading: boolean;
+  profileChecked: boolean;
   signInWithGoogle: () => Promise<void>;
   signInWithPhone: (
     phone: string,
@@ -36,6 +37,7 @@ const AuthContext = createContext<AuthContextType>({
   user: null,
   profile: null,
   loading: true,
+  profileChecked: false,
   signInWithGoogle: async () => {},
   signInWithPhone: async () => {
     throw new Error('signInWithPhone not implemented');
@@ -48,14 +50,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [profileChecked, setProfileChecked] = useState(false);
 
   const fetchProfile = async (uid: string) => {
+    setProfileChecked(false);
     const snap = await getDoc(doc(db, 'users', uid));
     if (snap.exists()) {
       setProfile(snap.data() as UserProfile);
     } else {
       setProfile(null);
     }
+    setProfileChecked(true);
   };
 
   useEffect(() => {
@@ -65,6 +70,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         await fetchProfile(firebaseUser.uid);
       } else {
         setProfile(null);
+        setProfileChecked(true);
       }
       setLoading(false);
     });
@@ -97,6 +103,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         user,
         profile,
         loading,
+        profileChecked,
         signInWithGoogle,
         signInWithPhone,
         signOutUser,


### PR DESCRIPTION
## Summary
- track whether the authenticated user's profile has been loaded in the auth context
- delay PrivateRoute navigation decisions until the profile lookup finishes to avoid showing the register page briefly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d552e65ff48330a211264def582f2b