### PR TITLE
Show loader during auth state resolution

### DIFF
--- a/src/components/FullScreenLoader.tsx
+++ b/src/components/FullScreenLoader.tsx
@@ -1,0 +1,17 @@
+const FullScreenLoader = () => (
+  <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500">
+    <div className="flex flex-col items-center gap-6 rounded-3xl bg-white/10 p-10 text-white shadow-2xl backdrop-blur-lg">
+      <div className="relative">
+        <div className="h-24 w-24 animate-spin rounded-full border-4 border-white/30 border-t-white" aria-hidden="true" />
+        <div className="absolute inset-0 animate-ping rounded-full border border-white/40" aria-hidden="true" />
+        <div className="absolute inset-6 rounded-full bg-white/20" aria-hidden="true" />
+      </div>
+      <div className="space-y-2 text-center">
+        <p className="text-2xl font-semibold tracking-wide">Preparando tu experiencia</p>
+        <p className="text-sm text-white/80">Ajustando los detalles para que todo quede perfecto...</p>
+      </div>
+    </div>
+  </div>
+);
+
+export default FullScreenLoader;

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,25 +1,12 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import FullScreenLoader from './FullScreenLoader';
 
 export const PrivateRoute = () => {
   const { user, profile, loading, profileChecked } = useAuth();
 
   if (loading || !profileChecked) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500">
-        <div className="flex flex-col items-center gap-6 rounded-3xl bg-white/10 p-10 text-white shadow-2xl backdrop-blur-lg">
-          <div className="relative">
-            <div className="h-24 w-24 animate-spin rounded-full border-4 border-white/30 border-t-white" aria-hidden="true" />
-            <div className="absolute inset-0 animate-ping rounded-full border border-white/40" aria-hidden="true" />
-            <div className="absolute inset-6 rounded-full bg-white/20" aria-hidden="true" />
-          </div>
-          <div className="space-y-2 text-center">
-            <p className="text-2xl font-semibold tracking-wide">Preparando tu experiencia</p>
-            <p className="text-sm text-white/80">Ajustando los detalles para que todo quede perfecto...</p>
-          </div>
-        </div>
-      </div>
-    );
+    return <FullScreenLoader />;
   }
 
   if (!user) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useNavigate } from 'react-router-dom';
+import FullScreenLoader from '@/components/FullScreenLoader';
 
 const GoogleIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
@@ -26,16 +27,17 @@ const GoogleIcon = (props: SVGProps<SVGSVGElement>) => (
 );
 
 const Login = () => {
-  const { signInWithGoogle, signInWithEmail, user, profile } = useAuth();
+  const { signInWithGoogle, signInWithEmail, user, profile, loading, profileChecked } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!profileChecked) return;
     if (user && profile) navigate('/');
     if (user && !profile) navigate('/register');
-  }, [user, profile, navigate]);
+  }, [user, profile, navigate, profileChecked]);
 
   const handleGoogle = async () => {
     await signInWithGoogle();
@@ -51,6 +53,10 @@ const Login = () => {
       setError('No pudimos iniciar sesión con esas credenciales.');
     }
   };
+
+  if (loading || (user && !profileChecked)) {
+    return <FullScreenLoader />;
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- extract a reusable full screen loader component
- reuse the loader in the private route gate
- display the loader on the login screen while the auth profile is loading to prevent flicker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5544edcf4833083248a6e58253b8a