### PR TITLE
Add project management and filtering for expenses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { ExpenseProvider } from "@/hooks/useExpenseStore";
 import Layout from "@/components/Layout";
 import ScrollToTop from "@/components/ScrollToTop";
 import AddExpense from "./pages/AddExpense";
+import Projects from "./pages/Projects";
 
 const queryClient = new QueryClient();
 
@@ -35,6 +36,7 @@ const App = () => (
                 <Route element={<Layout />}>
                   <Route index element={<Index />} />
                   <Route path="/projected" element={<ProjectedExpenses />} />
+                  <Route path="/projects" element={<Projects />} />
                   <Route path="/expenses/new" element={<AddExpense />} />
                   <Route path="/month/:year/:month" element={<MonthDetail />} />
                   <Route path="/category/:category" element={<CategoryDetail />} />

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -6,6 +6,7 @@ import {
   CalendarRange,
   Sparkles,
   ChevronDown,
+  FolderKanban,
 } from "lucide-react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -70,6 +71,7 @@ export function SideMenu() {
     { to: "/", label: "Inicio", icon: LayoutDashboard },
     buildCurrentMonthNavigationItem(),
     { to: "/projected", label: "Gastos proyectados", icon: Sparkles },
+    { to: "/projects", label: "Proyectos", icon: FolderKanban },
   ];
 
   const categoryItems: CategoryNavigationItem[] = categories

--- a/src/pages/AddExpense.tsx
+++ b/src/pages/AddExpense.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Calendar, ChevronRight, Loader2 } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -38,7 +38,7 @@ const parseDateValue = (value: string) => {
 
 const AddExpense = () => {
   const navigate = useNavigate();
-  const { categories, addExpense, addInstallmentExpense } = useExpenseStore();
+  const { categories, projects, addExpense, addInstallmentExpense } = useExpenseStore();
   const { toast } = useToast();
 
   const amountInputRef = useRef<HTMLInputElement>(null);
@@ -49,11 +49,18 @@ const AddExpense = () => {
   const [date, setDate] = useState(() => formatDateValue(new Date()));
   const [hasInstallments, setHasInstallments] = useState(false);
   const [installmentCount, setInstallmentCount] = useState("2");
+  const [projectId, setProjectId] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     amountInputRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (!projectId && projects.length > 0) {
+      setProjectId(projects[0].id);
+    }
+  }, [projectId, projects]);
 
   const quickDateOptions = useMemo(() => {
     const today = new Date();
@@ -88,15 +95,16 @@ const AddExpense = () => {
     setDate(formatDateValue(new Date()));
     setHasInstallments(false);
     setInstallmentCount("2");
+    setProjectId(projects[0]?.id ?? null);
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!amount || !category || !description) {
+    if (!amount || !category || !description || !projectId) {
       toast({
         title: "Faltan datos",
-        description: "Completa el monto, la categoría y el comentario",
+        description: "Completa el monto, la categoría, el comentario y el proyecto",
         variant: "destructive",
       });
       return;
@@ -134,7 +142,8 @@ const AddExpense = () => {
           category,
           description,
           installmentsNumber,
-          new Date(date)
+          new Date(date),
+          projectId
         );
 
         toast({
@@ -147,6 +156,7 @@ const AddExpense = () => {
           category,
           description,
           date,
+          projectId,
         });
 
         toast({
@@ -200,6 +210,44 @@ const AddExpense = () => {
           </div>
         </div>
       </div>
+
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-sky-600">
+            Proyecto
+          </h2>
+          <p className="text-sm text-slate-500">
+            Organiza tus gastos por proyecto para analizarlos fácilmente
+          </p>
+          <Select value={projectId ?? undefined} onValueChange={setProjectId}>
+            <SelectTrigger id="project" className="h-12">
+              <SelectValue placeholder="Selecciona un proyecto" />
+            </SelectTrigger>
+            <SelectContent>
+              {projects.map((project) => (
+                <SelectItem key={project.id} value={project.id}>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="inline-flex h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: project.color }}
+                    />
+                    {project.name}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-slate-500">
+            ¿Necesitas otro proyecto?{' '}
+            <Link
+              to="/projects"
+              className="font-medium text-sky-600 underline hover:text-sky-500"
+            >
+              Gestionar proyectos
+            </Link>
+          </p>
+        </div>
+      </section>
 
       <section className="space-y-4">
         <div>

--- a/src/pages/ProjectedExpenses.tsx
+++ b/src/pages/ProjectedExpenses.tsx
@@ -1,11 +1,26 @@
+import { useMemo, useState } from "react";
 import { ArrowLeft, Calendar, TrendingUp, TrendingDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { useExpenseStore } from "@/hooks/useExpenseStore";
+import { useExpenseStore, Project } from "@/hooks/useExpenseStore";
 import { formatCurrency, formatMonth } from "@/lib/formatters";
 import { Link } from "react-router-dom";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 const ProjectedExpenses = () => {
-  const { getTotalForMonth } = useExpenseStore();
+  const { getTotalForMonth, projects } = useExpenseStore();
+  const [selectedProjectId, setSelectedProjectId] = useState<string | "all">("all");
+
+  const projectFilter = selectedProjectId === "all" ? null : selectedProjectId;
+  const selectedProject: Project | null = useMemo(() => {
+    if (!projectFilter) return null;
+    return projects.find((project) => project.id === projectFilter) ?? null;
+  }, [projectFilter, projects]);
 
   const currentDate = new Date();
   const months = Array.from({ length: 12 }, (_, i) => {
@@ -18,7 +33,7 @@ const ProjectedExpenses = () => {
   const currentYear = currentDate.getFullYear();
 
   const getMonthData = (date: Date) => {
-    const total = getTotalForMonth(date);
+    const total = getTotalForMonth(date, projectFilter);
     const isPast = date < new Date(currentYear, currentMonth, 1);
     const isCurrent = date.getMonth() === currentMonth && date.getFullYear() === currentYear;
     const isFuture = date > new Date(currentYear, currentMonth + 1, 0);
@@ -82,6 +97,38 @@ const ProjectedExpenses = () => {
                 <TrendingUp className="h-4 w-4" /> Gastos futuros
               </p>
               <p className="mt-2 text-lg font-semibold text-white">{formatCurrency(totalFuture)}</p>
+            </div>
+          </div>
+          <div className="mt-4 rounded-2xl bg-white/15 p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/70">
+              Proyecto seleccionado
+            </p>
+            <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-white/80">
+                {selectedProject ? selectedProject.name : "Todos los proyectos"}
+              </p>
+              <Select
+                value={selectedProjectId}
+                onValueChange={(value) => setSelectedProjectId(value as string | "all")}
+              >
+                <SelectTrigger className="h-10 w-full border-white/40 bg-white/20 text-left text-sm font-medium text-white sm:w-60">
+                  <SelectValue placeholder="Selecciona un proyecto" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos los proyectos</SelectItem>
+                  {projects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="inline-flex h-2.5 w-2.5 rounded-full"
+                          style={{ backgroundColor: project.color }}
+                        />
+                        {project.name}
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
         </div>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,0 +1,327 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { ArrowLeft, FolderKanban, Plus, Save, Trash2 } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useExpenseStore, Project } from "@/hooks/useExpenseStore";
+import { useToast } from "@/hooks/use-toast";
+import { formatCurrency } from "@/lib/formatters";
+import { Badge } from "@/components/ui/badge";
+
+interface ProjectEditValues {
+  name: string;
+  color: string;
+}
+
+const DEFAULT_NEW_PROJECT_COLOR = "#2563EB";
+
+const Projects = () => {
+  const navigate = useNavigate();
+  const { projects, expenses, addProject, updateProject, deleteProject } = useExpenseStore();
+  const { toast } = useToast();
+
+  const [newProjectName, setNewProjectName] = useState("");
+  const [newProjectColor, setNewProjectColor] = useState(DEFAULT_NEW_PROJECT_COLOR);
+  const [projectEdits, setProjectEdits] = useState<Record<string, ProjectEditValues>>({});
+
+  useEffect(() => {
+    setProjectEdits(
+      projects.reduce<Record<string, ProjectEditValues>>((acc, project) => {
+        acc[project.id] = { name: project.name, color: project.color };
+        return acc;
+      }, {})
+    );
+  }, [projects]);
+
+  const projectSummaries = useMemo(
+    () =>
+      projects.map((project) => {
+        const relatedExpenses = expenses.filter((expense) => expense.projectId === project.id);
+        const totalAmount = relatedExpenses.reduce((sum, expense) => sum + expense.amount, 0);
+        return {
+          project,
+          totalAmount,
+          expensesCount: relatedExpenses.length,
+        };
+      }),
+    [expenses, projects]
+  );
+
+  const totalProjects = projects.length;
+  const totalTracked = projectSummaries.reduce((sum, summary) => sum + summary.totalAmount, 0);
+
+  const handleAddProject = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newProjectName.trim()) {
+      toast({
+        title: "Nombre requerido",
+        description: "Ingresa un nombre para el proyecto.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      await addProject(newProjectName.trim(), newProjectColor);
+      toast({
+        title: "Proyecto creado",
+        description: "Ahora puedes asignar gastos a este proyecto.",
+      });
+      setNewProjectName("");
+      setNewProjectColor(DEFAULT_NEW_PROJECT_COLOR);
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: "No se pudo crear el proyecto",
+        description: "Inténtalo nuevamente en unos instantes.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSaveProject = async (project: Project) => {
+    const edits = projectEdits[project.id];
+    if (!edits || !edits.name.trim()) {
+      toast({
+        title: "Datos incompletos",
+        description: "El proyecto debe tener un nombre.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      await updateProject(project.id, {
+        name: edits.name.trim(),
+        color: edits.color,
+      });
+      toast({
+        title: "Proyecto actualizado",
+        description: "Los cambios se guardaron correctamente.",
+      });
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: "No se pudo actualizar",
+        description: "Revisa la conexión y vuelve a intentarlo.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleDeleteProject = async (project: Project) => {
+    try {
+      await deleteProject(project.id);
+      toast({
+        title: "Proyecto eliminado",
+        description: "Los gastos permanecerán registrados en otros proyectos.",
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "No se pudo eliminar el proyecto.";
+      toast({
+        title: "Acción no disponible",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-6 pb-32 sm:pb-20">
+      <section className="space-y-4">
+        <div className="rounded-3xl bg-gradient-to-br from-blue-500 via-sky-500 to-emerald-500 p-5 text-white shadow-xl">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-white/20 text-white transition hover:bg-white/30"
+            >
+              <ArrowLeft className="h-5 w-5" />
+              <span className="sr-only">Volver</span>
+            </button>
+            <span className="rounded-full bg-white/20 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white">
+              Proyectos
+            </span>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+                <FolderKanban className="h-4 w-4" />
+                Gestión de proyectos
+              </div>
+              <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+                {totalProjects} {totalProjects === 1 ? "proyecto" : "proyectos"}
+              </h1>
+              <p className="text-xs text-white/70">
+                Seguimiento total: {formatCurrency(totalTracked)}
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              <Link
+                to="/expenses/new"
+                className="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/30"
+              >
+                <Plus className="h-4 w-4" /> Nuevo gasto
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <Card className="border border-slate-200/70 bg-white/80 shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-base font-semibold text-slate-900">
+              Crear un proyecto
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleAddProject} className="grid gap-4 sm:grid-cols-[1fr_auto_auto] sm:items-end">
+              <div className="space-y-2">
+                <Label htmlFor="project-name">Nombre</Label>
+                <Input
+                  id="project-name"
+                  value={newProjectName}
+                  onChange={(event) => setNewProjectName(event.target.value)}
+                  placeholder="Ej. Casa nueva"
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="project-color">Color</Label>
+                <Input
+                  id="project-color"
+                  type="color"
+                  value={newProjectColor}
+                  onChange={(event) => setNewProjectColor(event.target.value)}
+                  className="h-10 w-full cursor-pointer"
+                />
+              </div>
+              <Button type="submit" className="mt-2 inline-flex items-center gap-2 sm:mt-0">
+                <Plus className="h-4 w-4" /> Agregar
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-sky-600">
+              Proyectos activos
+            </p>
+            <h2 className="text-xl font-semibold text-slate-900">Gestiona tus proyectos</h2>
+          </div>
+        </div>
+
+        {projectSummaries.length === 0 ? (
+          <div className="rounded-3xl border border-dashed border-slate-200 bg-white/70 p-10 text-center shadow-sm">
+            <div className="mb-2 text-3xl">📂</div>
+            <p className="text-sm text-slate-500">
+              Crea tu primer proyecto para organizar los gastos.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {projectSummaries.map(({ project, totalAmount, expensesCount }) => {
+              const edits = projectEdits[project.id] ?? { name: project.name, color: project.color };
+              const hasExpenses = expensesCount > 0;
+              return (
+                <Card key={project.id} className="border border-slate-200/70 bg-white/80 shadow-sm">
+                  <CardHeader className="flex flex-row items-center justify-between">
+                    <CardTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+                      <span
+                        className="inline-flex h-3 w-3 rounded-full"
+                        style={{ backgroundColor: edits.color }}
+                      />
+                      {project.name}
+                    </CardTitle>
+                    <Badge variant="secondary" className="text-xs">
+                      {expensesCount} {expensesCount === 1 ? "gasto" : "gastos"}
+                    </Badge>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid gap-3 sm:grid-cols-[2fr_1fr] sm:items-center">
+                      <div className="space-y-2">
+                        <Label htmlFor={`name-${project.id}`}>Nombre</Label>
+                        <Input
+                          id={`name-${project.id}`}
+                          value={edits.name}
+                          onChange={(event) =>
+                            setProjectEdits((prev) => ({
+                              ...prev,
+                              [project.id]: {
+                                ...(prev[project.id] ?? edits),
+                                name: event.target.value,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`color-${project.id}`}>Color</Label>
+                        <Input
+                          id={`color-${project.id}`}
+                          type="color"
+                          value={edits.color}
+                          onChange={(event) =>
+                            setProjectEdits((prev) => ({
+                              ...prev,
+                              [project.id]: {
+                                ...(prev[project.id] ?? edits),
+                                color: event.target.value,
+                              },
+                            }))
+                          }
+                          className="h-10 w-full cursor-pointer"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-3 text-sm text-slate-600">
+                      <p>
+                        Total registrado: <span className="font-semibold">{formatCurrency(totalAmount)}</span>
+                      </p>
+                    </div>
+
+                    <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="inline-flex items-center gap-2"
+                        onClick={() => handleSaveProject(project)}
+                      >
+                        <Save className="h-4 w-4" /> Guardar cambios
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="inline-flex items-center gap-2 text-red-600 hover:text-red-700"
+                        onClick={() => handleDeleteProject(project)}
+                        disabled={hasExpenses}
+                        title={
+                          hasExpenses
+                            ? "No puedes eliminar un proyecto con gastos asociados"
+                            : undefined
+                        }
+                      >
+                        <Trash2 className="h-4 w-4" /> Eliminar
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default Projects;


### PR DESCRIPTION
## Summary
- add a project entity to the expense store with Firestore persistence and CRUD helpers
- let users pick projects when creating or editing expenses and filter dashboards by project
- introduce a projects management page plus navigation entry for quick access

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55548f2e083309b5548fffd77a695