### PR TITLE
feat: allow deleting expenses

### DIFF
--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -17,7 +17,7 @@ import {
 const CategoryDetail = () => {
   const { category } = useParams<{ category: string }>();
   const navigate = useNavigate();
-  const { expenses, categories, updateExpense, projects } = useExpenseStore();
+  const { expenses, categories, updateExpense, projects, deleteExpense } = useExpenseStore();
   const [selectedProjectId, setSelectedProjectId] = useState<string | "all">("all");
 
   const selectedMonth = new Date();
@@ -219,6 +219,10 @@ const CategoryDetail = () => {
           expense={editingExpense}
           onSave={async (updatedData) => {
             await updateExpense(editingExpense.id, updatedData);
+            setEditingExpense(null);
+          }}
+          onDelete={async (expenseId) => {
+            await deleteExpense(expenseId);
             setEditingExpense(null);
           }}
           onClose={() => setEditingExpense(null)}


### PR DESCRIPTION
## Summary
- enable deleting expenses from the edit modal with a confirmation prompt
- disable actions while deletion is in progress and show destructive styling
- wire category detail view to call the store delete handler after confirmation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da780627648330acf27672c55571c8