### PR TITLE
Format pie chart total with compact currency

### DIFF
--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -8,6 +8,38 @@ export const formatCurrency = (amount: number): string => {
   }).format(amount);
 };
 
+export const formatCompactCurrency = (amount: number): string => {
+  const absoluteAmount = Math.abs(amount);
+  const sign = amount < 0 ? '-' : '';
+
+  if (absoluteAmount >= 1_000_000) {
+    const compactValue = absoluteAmount / 1_000_000;
+    const decimals = compactValue >= 10 ? 0 : 1;
+    const formatted = new Intl.NumberFormat('es-AR', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }).format(compactValue);
+    return `${sign}$${formatted}M`;
+  }
+
+  if (absoluteAmount >= 1_000) {
+    const compactValue = absoluteAmount / 1_000;
+    const decimals = compactValue >= 10 ? 0 : 1;
+    const formatted = new Intl.NumberFormat('es-AR', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    }).format(compactValue);
+    return `${sign}$${formatted}K`;
+  }
+
+  const formatted = new Intl.NumberFormat('es-AR', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: Number.isInteger(amount) ? 0 : 2,
+  }).format(absoluteAmount);
+
+  return `${sign}$${formatted}`;
+};
+
 const THOUSANDS_REGEX = /\B(?=(\d{3})+(?!\d))/g;
 
 export const formatCurrencyInput = (value: string): string => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,7 +5,7 @@ import { ExpenseChart } from "@/components/ExpenseChart";
 import { CategoryList } from "@/components/CategoryList";
 import { MonthNavigator } from "@/components/MonthNavigator";
 import { Expense, Project, useExpenseStore } from "@/hooks/useExpenseStore";
-import { formatCurrency } from "@/lib/formatters";
+import { formatCompactCurrency, formatCurrency } from "@/lib/formatters";
 import { EditExpenseModal } from "@/components/EditExpenseModal";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
@@ -77,13 +77,13 @@ const Index = () => {
                   outerRadius={125}
                   centerLabel={
                     <div className="flex flex-col items-center text-white">
-                      <span className="text-xs uppercase tracking-[0.25em] text-white/70">
+                      <span className="text-[10px] uppercase tracking-[0.35em] text-white/70">
                         {summaryLabel}
                       </span>
-                      <span className="mt-1 inline-flex items-center rounded-xl bg-white/15 px-4 py-1 text-3xl font-semibold leading-tight shadow-inner">
-                        {formatCurrency(monthlyTotal)}
+                      <span className="mt-2 text-5xl font-semibold leading-tight tracking-tight sm:text-6xl">
+                        {formatCompactCurrency(monthlyTotal)}
                       </span>
-                      <span className="mt-1 text-xs capitalize text-white/80">{monthText}</span>
+                      <span className="mt-2 text-xs capitalize text-white/80">{monthText}</span>
                     </div>
                   }
                 />


### PR DESCRIPTION
## Summary
- add a compact currency formatter that abbreviates thousands with K and millions with M
- display the pie chart center total with the compact formatter and larger typography so it fills the chart interior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de9ee48c7083309343c5eba98d27d0