### PR TITLE
Fix monthly projection calculations

### DIFF
--- a/src/hooks/useExpenseStore.tsx
+++ b/src/hooks/useExpenseStore.tsx
@@ -534,33 +534,25 @@ export const ExpenseProvider = ({ children }: { children: ReactNode }) => {
     [expenses, user]
   );
 
+  const getMonthKeyFromDate = (date: Date) =>
+    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
   const getExpensesForMonth = useCallback(
     (date: Date) => {
-      const year = date.getFullYear();
-      const month = date.getMonth();
+      const targetMonthKey = getMonthKeyFromDate(date);
 
-      return expenses.filter((expense) => {
-        const expenseDate = new Date(expense.date);
-        return (
-          expenseDate.getFullYear() === year &&
-          expenseDate.getMonth() === month
-        );
-      });
+      return expenses.filter(
+        (expense) => expense.date.slice(0, 7) === targetMonthKey
+      );
     },
     [expenses]
   );
 
   const getIncomesForMonth = useCallback(
     (date: Date) => {
-      const year = date.getFullYear();
-      const month = date.getMonth();
+      const targetMonthKey = getMonthKeyFromDate(date);
 
-      return incomes.filter((income) => {
-        const incomeDate = new Date(income.date);
-        return (
-          incomeDate.getFullYear() === year && incomeDate.getMonth() === month
-        );
-      });
+      return incomes.filter((income) => income.date.slice(0, 7) === targetMonthKey);
     },
     [incomes]
   );


### PR DESCRIPTION
## Summary
- normalize month comparisons in the expense store to avoid repeated totals across months
- rebuild the projected expenses calendar using month starts to ensure past/current/future sections display correct data
- use stable month identifiers when rendering monthly cards in the projection view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e65a2529a88330b8dc6739f68bedfd