### PR TITLE
Fix category navigation to respect selected month

### DIFF
--- a/src/components/CategoryList.tsx
+++ b/src/components/CategoryList.tsx
@@ -13,9 +13,13 @@ interface Category {
 
 interface CategoryListProps {
   categories: Category[];
+  onCategoryClick?: (categoryName: string) => void;
 }
 
-export const CategoryList: React.FC<CategoryListProps> = ({ categories }) => {
+export const CategoryList: React.FC<CategoryListProps> = ({
+  categories,
+  onCategoryClick,
+}) => {
   const navigate = useNavigate();
 
   if (categories.length === 0) {
@@ -28,6 +32,11 @@ export const CategoryList: React.FC<CategoryListProps> = ({ categories }) => {
   }
 
   const handleCategoryClick = (categoryName: string) => {
+    if (onCategoryClick) {
+      onCategoryClick(categoryName);
+      return;
+    }
+
     navigate(`/category/${encodeURIComponent(categoryName)}`);
   };
 

--- a/src/pages/CategoryDetail.tsx
+++ b/src/pages/CategoryDetail.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { ArrowLeft, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { Expense, Project, useExpenseStore } from "@/hooks/useExpenseStore";
 import { formatCurrency } from "@/lib/formatters";
 import { EditExpenseModal } from "@/components/EditExpenseModal";
@@ -17,10 +17,27 @@ import {
 const CategoryDetail = () => {
   const { category } = useParams<{ category: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { expenses, categories, updateExpense, projects, deleteExpense } = useExpenseStore();
   const [selectedProjectId, setSelectedProjectId] = useState<string | "all">("all");
 
-  const selectedMonth = new Date();
+  const searchParams = useMemo(
+    () => new URLSearchParams(location.search),
+    [location.search]
+  );
+  const yearParam = searchParams.get("year");
+  const monthParam = searchParams.get("month");
+
+  const selectedMonth = useMemo(() => {
+    const yearNumber = yearParam ? parseInt(yearParam, 10) : NaN;
+    const monthNumber = monthParam ? parseInt(monthParam, 10) : NaN;
+
+    if (!Number.isNaN(yearNumber) && !Number.isNaN(monthNumber) && monthNumber >= 1 && monthNumber <= 12) {
+      return new Date(yearNumber, monthNumber - 1, 1);
+    }
+
+    return new Date();
+  }, [monthParam, yearParam]);
   const monthText = selectedMonth.toLocaleDateString("es", { month: "long", year: "numeric" });
 
   const categoryInfo = categories.find((cat) => cat.name === category);


### PR DESCRIPTION
## Summary
- allow the monthly category list to provide a custom navigation handler
- pass the selected month from the month detail page when opening a category
- read the month from query parameters in the category detail page to filter expenses correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6613315208330b023a318f651530d