### PR TITLE
Fix currency formatting when editing amounts

### DIFF
--- a/src/components/EditExpenseModal.tsx
+++ b/src/components/EditExpenseModal.tsx
@@ -40,7 +40,9 @@ export const EditExpenseModal: React.FC<EditExpenseModalProps> = ({
   onDelete,
 }) => {
   const { projects } = useExpenseStore();
-  const [amount, setAmount] = useState(formatCurrencyInput(expense.amount.toFixed(2)));
+  const [amount, setAmount] = useState(() =>
+    formatCurrencyInput(expense.amount.toFixed(2).replace('.', ','))
+  );
   const [category, setCategory] = useState(expense.category);
   const [description, setDescription] = useState(expense.description);
   const [date, setDate] = useState(expense.date);

--- a/src/components/EditIncomeModal.tsx
+++ b/src/components/EditIncomeModal.tsx
@@ -23,8 +23,8 @@ export const EditIncomeModal = ({
   onClose,
   onDelete,
 }: EditIncomeModalProps) => {
-  const [amount, setAmount] = useState(
-    formatCurrencyInput(income.amount.toFixed(2))
+  const [amount, setAmount] = useState(() =>
+    formatCurrencyInput(income.amount.toFixed(2).replace('.', ','))
   );
   const [description, setDescription] = useState(income.description);
   const [date, setDate] = useState(income.date);


### PR DESCRIPTION
## Summary
- ensure the edit expense modal pre-fills amounts with comma decimal formatting
- normalize the edit income modal amount initialization to match the expected input format

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e663d81a5c8330afe8ed09df0b8c35