### PR TITLE
Improve projected expenses month search responsiveness

### DIFF
--- a/src/pages/ProjectedExpenses.tsx
+++ b/src/pages/ProjectedExpenses.tsx
@@ -197,11 +197,11 @@ const ProjectedExpenses = () => {
                 type="month"
                 value={searchMonth}
                 onChange={(event) => setSearchMonth(event.target.value)}
-                className="h-10 rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
+                className="h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900 shadow-sm focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
               />
               <button
                 type="submit"
-                className="inline-flex h-10 items-center justify-center rounded-lg bg-sky-600 px-4 text-sm font-semibold text-white transition hover:bg-sky-700"
+                className="inline-flex h-10 w-full items-center justify-center rounded-lg bg-sky-600 px-4 text-sm font-semibold text-white transition hover:bg-sky-700 sm:w-auto"
               >
                 Ir al mes
               </button>


### PR DESCRIPTION
## Summary
- ensure the month search form on the projected expenses page uses full-width controls on small screens for a mobile-first layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6645dacd483309425ef7d52c7b2e2